### PR TITLE
Fix microdep-map: font 404s (#94), one-way flow popups (#93), stale banner on historic data (#95)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -4,15 +4,17 @@
    ============================================================ */
 
 /* Self-hosted fonts (DM Sans + JetBrains Mono, latin + latin-ext).
-   Vendored into fonts/ per the no-CDN policy — replaces the former
-   Google Fonts web import. latin-ext covers Croatian diacritics
-   (c-caron, etc.) in host labels. */
+   Vendored into <maproot>/fonts/ per the no-CDN policy — replaces the
+   former Google Fonts web import. latin-ext covers Croatian diacritics
+   (c-caron, etc.) in host labels.
+   NOTE: url() paths are resolved relative to THIS css file (in css/),
+   so they must be ../fonts/… — not fonts/… (issue #94: fonts 404'd). */
 @font-face {
   font-family: 'DM Sans';
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('fonts/dmsans-400-latinext.woff2') format('woff2');
+  src: url('../fonts/dmsans-400-latinext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -20,7 +22,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('fonts/dmsans-400-latin.woff2') format('woff2');
+  src: url('../fonts/dmsans-400-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -28,7 +30,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('fonts/dmsans-500-latinext.woff2') format('woff2');
+  src: url('../fonts/dmsans-500-latinext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -36,7 +38,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('fonts/dmsans-500-latin.woff2') format('woff2');
+  src: url('../fonts/dmsans-500-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -44,7 +46,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('fonts/dmsans-600-latinext.woff2') format('woff2');
+  src: url('../fonts/dmsans-600-latinext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -52,7 +54,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('fonts/dmsans-600-latin.woff2') format('woff2');
+  src: url('../fonts/dmsans-600-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -60,7 +62,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('fonts/dmsans-700-latinext.woff2') format('woff2');
+  src: url('../fonts/dmsans-700-latinext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -68,7 +70,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: url('fonts/dmsans-700-latin.woff2') format('woff2');
+  src: url('../fonts/dmsans-700-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -76,7 +78,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('fonts/jetbrainsmono-400-latinext.woff2') format('woff2');
+  src: url('../fonts/jetbrainsmono-400-latinext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -84,7 +86,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url('fonts/jetbrainsmono-400-latin.woff2') format('woff2');
+  src: url('../fonts/jetbrainsmono-400-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -92,7 +94,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('fonts/jetbrainsmono-500-latinext.woff2') format('woff2');
+  src: url('../fonts/jetbrainsmono-500-latinext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -100,7 +102,7 @@
   font-style: normal;
   font-weight: 500;
   font-display: swap;
-  src: url('fonts/jetbrainsmono-500-latin.woff2') format('woff2');
+  src: url('../fonts/jetbrainsmono-500-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
@@ -108,7 +110,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('fonts/jetbrainsmono-600-latinext.woff2') format('woff2');
+  src: url('../fonts/jetbrainsmono-600-latinext.woff2') format('woff2');
   unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 @font-face {
@@ -116,7 +118,7 @@
   font-style: normal;
   font-weight: 600;
   font-display: swap;
-  src: url('fonts/jetbrainsmono-600-latin.woff2') format('woff2');
+  src: url('../fonts/jetbrainsmono-600-latin.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -3445,9 +3445,11 @@ function extend_unidirectional_links() {
             var halfLine = L.curve(['M', orig.bp0, 'Q', orig.bp1, orig.bp2], { color: currentColor, fill: false, weight: 6 });
             halfLine._bezierP0 = orig.bp0; halfLine._bezierP1 = orig.bp1; halfLine._bezierP2 = orig.bp2;
             halfLine._fullStart = orig.fullStart; halfLine._fullEnd = orig.fullEnd; halfLine._fullControl = orig.fullControl;
+            halfLine._panelPopup = orig.popup; halfLine._panelSource = orig.source;
+            if (orig.baseColor) halfLine._baseColor = orig.baseColor;
             halfLine.addTo(mymap);
             if (orig.tooltip) halfLine.bindTooltip(orig.tooltip, {"sticky":true});
-            if (orig.popup) halfLine.on('click', function(){ openLinkPanel(orig.popup); });
+            if (orig.popup) halfLine.on('click', function(e){ setHighlightedLink(e.target); openLinkPanel(e.target._panelPopup, e.target._panelSource); });
             halfLine.on("mouseover", function(e){ if (!mouseover) { mouseover = true; color_store[L.stamp(e.target)] = e.target.options.color; e.target.bringToFront(); taint_link(e.target, "blue"); } });
             halfLine.on("mouseout", function(e){ taint_link(e.target, e.target._baseColor || color_store[L.stamp(e.target)]); mouseover = false; });
             linkByName[abs] = halfLine;
@@ -3463,17 +3465,28 @@ function extend_unidirectional_links() {
             if (link._fullStart && link._fullEnd && link._fullControl) {
                 var color = link.options.color;
                 var tooltipContent = link.getTooltip() ? link.getTooltip().getContent() : null;
-                var popupContent = link.getPopup ? null : null;
-                extendedLinks[abs] = { bp0: link._bezierP0, bp1: link._bezierP1, bp2: link._bezierP2, fullStart: link._fullStart, fullEnd: link._fullEnd, fullControl: link._fullControl, tooltip: tooltipContent, popup: popupContent };
+                // Preserve the click->details-panel popup (+ source data and base
+                // colour) that annotate_link stashed on the layer. The old code
+                // hardcoded this to null, so rebuilt one-way links lost their click
+                // handler entirely (issue #93: no popup on TCP trace error / route
+                // change flows, which are drawn one-way).
+                var popupContent = link._panelPopup;
+                var sourceData = link._panelSource;
+                var baseColor = link._baseColor;
+                extendedLinks[abs] = { bp0: link._bezierP0, bp1: link._bezierP1, bp2: link._bezierP2, fullStart: link._fullStart, fullEnd: link._fullEnd, fullControl: link._fullControl, tooltip: tooltipContent, popup: popupContent, source: sourceData, baseColor: baseColor };
                 link.remove();
                 var newBP0 = link._fullStart; var newBP2 = link._fullEnd;
                 var cubicC1 = link._fullControl; var cubicC2 = link._bezierP1 || link._fullControl;
                 var newLine = L.curve(['M', newBP0, 'C', cubicC1, cubicC2, newBP2], { color: color, fill: false, weight: 6 });
                 newLine._bezierP0 = link._bezierP0; newLine._bezierP1 = link._bezierP1; newLine._bezierP2 = link._bezierP2;
                 newLine._fullStart = link._fullStart; newLine._fullEnd = link._fullEnd; newLine._fullControl = link._fullControl;
+                newLine._panelPopup = popupContent; newLine._panelSource = sourceData;
+                if (baseColor) newLine._baseColor = baseColor;
                 newLine.addTo(mymap);
                 if (tooltipContent) newLine.bindTooltip(tooltipContent, {"sticky":true});
-                if (popupContent) newLine.on('click', function(){ openLinkPanel(popupContent); });
+                // Read the popup off the clicked layer (not the loop-scoped var) so
+                // each one-way link opens its own panel, not the last link's.
+                if (popupContent) newLine.on('click', function(e){ setHighlightedLink(e.target); openLinkPanel(e.target._panelPopup, e.target._panelSource); });
                 newLine.on("mouseover", function(e){ if (!mouseover) { mouseover = true; color_store[L.stamp(e.target)] = e.target.options.color; e.target.bringToFront(); taint_link(e.target, "blue"); } });
                 newLine.on("mouseout", function(e){ taint_link(e.target, e.target._baseColor || color_store[L.stamp(e.target)]); mouseover = false; });
                 linkByName[abs] = newLine;


### PR DESCRIPTION
Resolves three issues reported by @ottojwittner.

### #94 — fonts not loading
`@font-face` `src` URLs in `css/microdep-map.css` were `url('fonts/…')`. A stylesheet's relative URLs resolve against the stylesheet's own location (`css/`), so the browser requested `/microdep/css/fonts/…` — but the woff2 files are installed at `<maproot>/fonts/`. Every font 404'd (the console errors in the issue) and the UI fell back to system fonts.

Fixed by using `url('../fonts/…')`. Verified on a live host: `/microdep/fonts/dmsans-400-latin.woff2` → **200** (previously `/microdep/css/fonts/…` → 404).

### #93 — no popup on one-way trace-error flows
`extend_unidirectional_links()` rebuilds one-way links (e.g. TCP trace error / route change topologies, drawn one-way) into new `L.curve` layers, but set the popup via `var popupContent = link.getPopup ? null : null;` — always `null`. So the rebuilt layer never got a click handler: clicking a coloured one-way flow did nothing (no details panel) even though the link had data.

Fixed by carrying over the `_panelPopup` / `_panelSource` / `_baseColor` that `annotate_link` stashes on the layer and re-binding the click handler — reading the popup off the clicked layer (`e.target`) rather than a loop-scoped var, so each link opens its own panel. Applied in both the cache-rebuild and initial-extend paths.

### #95 — stale "refresh now" banner on historic data
The orange "Data is N old / refresh now" banner is driven by the time since the last fetch, so it appeared even when viewing a historic date — where the data is meant to be old and refreshing changes nothing.

`get_connections()` now publishes the viewed window's end as `window._microdep_view_end`, and `_check_stale_banner()` suppresses the banner whenever that end is in the past (not a live view). Live Day/Week/4-week and current-hour views still get the nudge.

### Testing
- JS syntax-checked (module + extracted inline); CSS font paths verified (14× `../fonts/`).
- Deployed to a live test host. #94 confirmed via HTTP (200 vs prior 404). #93 logic mirrors the working bidirectional-link path; #95 gated on the published window end. #93/#95 want a final visual check where the relevant data exists.

Closes #93
Closes #94
Closes #95