### PR TITLE
Suppress stale-data banner on historic views (#95)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/index.html
+++ b/microdep/perfsonar-microdep/microdep-map/index.html
@@ -649,8 +649,20 @@
         var period = window.refresh_period || 60000;
         return auto ? Math.max(2 * period, 60000) : 5 * 60 * 1000;
       }
+      // The "data is stale / refresh now" nudge only makes sense for live data.
+      // When the viewed window ends in the past (a historic date) the data is
+      // meant to be old, so suppress the banner there (issue #95). The window
+      // end is published by get_connections as window._microdep_view_end.
+      function _viewing_live_data() {
+        var endIso = window._microdep_view_end;
+        if (!endIso) return true;                    // unknown yet -> don't suppress
+        var endMs = Date.parse(endIso);
+        if (isNaN(endMs)) return true;
+        return endMs >= Date.now() - 5 * 60 * 1000;  // window reaches ~now -> live
+      }
       function _check_stale_banner() {
         if (!staleBanner) return;
+        if (!_viewing_live_data()) { staleBanner.hidden = true; return; }
         if (!window._lastRefreshAt || _staleDismissed) { staleBanner.hidden = true; return; }
         var ageMs = Date.now() - window._lastRefreshAt;
         if (ageMs < _stale_threshold_ms()) { staleBanner.hidden = true; return; }

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -4022,6 +4022,10 @@ function get_connections(){
 	start= new Date(msstart).toISOString(); end= new Date(msend).toISOString();
 	if ( period < 2*24 ){ tloss=1000; } else if ( period <= 7*24 ){ tloss=5000; } else { tloss=60000; }
     }
+    // Publish the viewed window's end so the inline stale-data banner can tell
+    // live from historic views: a window ending in the past is historic, so the
+    // "data is N old / refresh now" nag is suppressed there (issue #95).
+    window._microdep_view_end = end;
     last_hits=[]; summary=[]; var now = new Date();
     if ( ! sum_etype || typeof sum_etype == 'undefined' || start.substr(0,10) === now.toISOString().substr(0,10) || period < 24){
 	var url="elastic-get-date-type.pl?net=" + parms.net + "&index=" + index + "&event_type=" + etype + "&start=" + start + "&end=" + end ;


### PR DESCRIPTION
Follow-up to #96 (which landed #93 + #94). This adds the remaining fix.

### #95 — stale "refresh now" banner on historic data
The orange "Data is N old / refresh now" banner is driven by the time since the last fetch, so it appeared even when viewing a historic date — where the data is meant to be old and refreshing changes nothing.

`get_connections()` now publishes the viewed window's end as `window._microdep_view_end`, and the inline `_check_stale_banner()` suppresses the banner whenever that end is in the past (not a live view). Live Day/Week/4-week and current-hour views still get the nudge.

### Testing
- JS syntax-checked (module + extracted inline). Deployed to a live test host. Easy to verify: open a past date → no banner; stay on today → banner returns after the staleness threshold.

Closes #95