### PR TITLE
Fix flow-line tooltip refresh (#98) and curve-chart jitter index on Net-6 (#100)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -3440,16 +3440,27 @@ function extend_unidirectional_links() {
     for (var abs in extendedLinks) {
         if (linkByName[abs] && extendedLinks[abs]) {
             var orig = extendedLinks[abs];
-            var currentColor = linkByName[abs].options.color;
-            linkByName[abs].remove();
+            var live = linkByName[abs];
+            // Geometry (bezier points) comes from the cache - it doesn't change -
+            // but the DISPLAY content (colour/tooltip/popup/source/base colour)
+            // must be read from the LIVE link, which annotate_link refreshes on
+            // every repaint. Reading the stale cached tooltip/popup here left the
+            // mouse-over tooltip showing the previous property/event (issue #98)
+            // even though the colour (read live) did update.
+            var currentColor = live.options.color;
+            var liveTip = (live.getTooltip && live.getTooltip()) ? live.getTooltip().getContent() : orig.tooltip;
+            var livePopup = (live._panelPopup != null) ? live._panelPopup : orig.popup;
+            var liveSource = (live._panelSource !== undefined) ? live._panelSource : orig.source;
+            var liveBase = live._baseColor || orig.baseColor;
+            live.remove();
             var halfLine = L.curve(['M', orig.bp0, 'Q', orig.bp1, orig.bp2], { color: currentColor, fill: false, weight: 6 });
             halfLine._bezierP0 = orig.bp0; halfLine._bezierP1 = orig.bp1; halfLine._bezierP2 = orig.bp2;
             halfLine._fullStart = orig.fullStart; halfLine._fullEnd = orig.fullEnd; halfLine._fullControl = orig.fullControl;
-            halfLine._panelPopup = orig.popup; halfLine._panelSource = orig.source;
-            if (orig.baseColor) halfLine._baseColor = orig.baseColor;
+            halfLine._panelPopup = livePopup; halfLine._panelSource = liveSource;
+            if (liveBase) halfLine._baseColor = liveBase;
             halfLine.addTo(mymap);
-            if (orig.tooltip) halfLine.bindTooltip(orig.tooltip, {"sticky":true});
-            if (orig.popup) halfLine.on('click', function(e){ setHighlightedLink(e.target); openLinkPanel(e.target._panelPopup, e.target._panelSource); });
+            if (liveTip) halfLine.bindTooltip(liveTip, {"sticky":true});
+            if (livePopup) halfLine.on('click', function(e){ setHighlightedLink(e.target); openLinkPanel(e.target._panelPopup, e.target._panelSource); });
             halfLine.on("mouseover", function(e){ if (!mouseover) { mouseover = true; color_store[L.stamp(e.target)] = e.target.options.color; e.target.bringToFront(); taint_link(e.target, "blue"); } });
             halfLine.on("mouseout", function(e){ taint_link(e.target, e.target._baseColor || color_store[L.stamp(e.target)]); mouseover = false; });
             linkByName[abs] = halfLine;


### PR DESCRIPTION
Two map fixes reported by @ottojwittner.

### #98 — mouse-over tooltip not updated on property/event change
On a one-way flow line (TCP route error / route change), switching the **property** or **event** updated the line colour and the click popup, but the **mouse-over tooltip stayed stuck** on the previous values.

`extend_unidirectional_links()` rebuilds one-way links from a geometry cache. Its first loop read the **colour** from the live link (so colour refreshed) but the **tooltip/popup/source/base-colour** from the *stale cache*. `annotate_link` refreshes those on the live link each repaint, but the rebuild then replaced the link with the stale-tooltip copy.

Fix: read tooltip/popup/source/base-colour from the **live link** too (cache as fallback), matching how the colour is already handled. Geometry still comes from the cache.

### #100 — curve chart gets the wrong index on Net-6
The link-panel **"Queues"** button built the curve-chart index as `parms.net + '_jitter'`, i.e. `dragonlab_6_jitter` on Net-6 — but jitter events for both nets live in the configured `dragonlab_jitter` index. The curve queried a non-existent index → "No jitter data" despite data being present. (On Net-4 the concatenation happened to equal the configured index, masking the bug.)

Fix: look the index up from config (`event_index['jitter']`, old concatenation only as fallback), matching the adjacent "Unavailability" button and the heatmap/property curve openers.

### Testing
- JS syntax-checked, deployed to a test host.
- #98 wants a visual hover check where one-way TCP route data exists; #100 is verifiable on Net-6 (Queues curve now hits `dragonlab_jitter`).

Closes #98
Closes #100