### PR TITLE
Curve chart: use configured jitter index on Net-6 (#100)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -1481,7 +1481,11 @@ function link_popup(link){
 	}
 
 	// --- Queues (jitter / h_ddelay) ---
-	var queuesUrl = 'curve-chart.html?net=' + parms.net + '&index=' + parms.net + '_jitter&from=' + link.from + '&to=' + link.to + '&event=jitter&property=h_ddelay&start=' + start + '&end=' + end + "&title=From " + link.from + " to " + link.to;
+	// Use the configured jitter index (e.g. dragonlab_jitter, shared by both
+	// nets) - NOT parms.net + '_jitter', which becomes dragonlab_6_jitter on
+	// Net-6 and reports "No jitter data" (issue #100).
+	var queuesIndex = (event_index && event_index['jitter']) ? event_index['jitter'] : (parms.net + '_jitter');
+	var queuesUrl = 'curve-chart.html?net=' + parms.net + '&index=' + queuesIndex + '&from=' + link.from + '&to=' + link.to + '&event=jitter&property=h_ddelay&start=' + start + '&end=' + end + "&title=From " + link.from + " to " + link.to;
 	var queuesBtn = document.createElement("button");
 	queuesBtn.className = "knapp";
 	queuesBtn.title = "Curve over queues in this period";


### PR DESCRIPTION
Follow-up: this fix was committed right after #99 merged, so it missed that squash. Re-applied cleanly here.

### #100 — curve chart gets the wrong index on Net-6
The link-panel **"Queues"** button built the curve-chart index as `parms.net + '_jitter'` → `dragonlab_6_jitter` on Net-6, but jitter events for both networks live in the configured `dragonlab_jitter` index. The curve queried a non-existent index and reported "No jitter data" despite data being present. (On Net-4 the concatenation happened to equal the configured index, masking the bug.)

Fix: look the index up from config (`event_index['jitter']`, with the old concatenation only as a fallback), matching the adjacent "Unavailability" button and the heatmap/property curve openers.

Verified: deployed to a test host; on Net-6 the Queues curve now queries `dragonlab_jitter`.

Closes #100