### PR TITLE
Link-panel UX (swap-right, double-click copy + toast, host wrapping) + asset cache-busting

### DIFF
--- a/microdep/perfsonar-microdep/etc/apache-microdep-map.conf
+++ b/microdep/perfsonar-microdep/etc/apache-microdep-map.conf
@@ -40,5 +40,11 @@ Alias /microdep /usr/lib/perfsonar/microdep-map
     Header set X-XSS-Protection "1; mode=block"
     Header set X-Content-Type-Options "nosniff"
 #    Header set Content-Security-Policy "default-src 'self' 'unsafe-inline' ; img-src 'self'; style-src 'self'; connect-src * "
+    # Cache-busting: always revalidate the app's HTML/JS/CSS so a deployed
+    # change takes effect on a normal reload (server answers 304 when the file
+    # is unchanged, so it's cheap). Fonts/images keep their default caching.
+    <FilesMatch "\.(html|js|css)$">
+        Header set Cache-Control "no-cache"
+    </FilesMatch>
 </Directory>
 

--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -1591,6 +1591,32 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sor
 .link-host:hover { color: var(--c-accent); }
 .link-host.copied { color: var(--c-accent); }
 
+/* Transient "copied to clipboard" toast (bottom-centre, theme-aware). */
+.copy-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 28px;
+    transform: translateX(-50%) translateY(8px);
+    z-index: 10000;
+    max-width: 80vw;
+    padding: 9px 16px;
+    background: var(--c-elevated);
+    color: var(--c-text);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r);
+    box-shadow: 0 6px 24px rgba(0, 0, 0, .35);
+    font-size: .85rem;
+    font-weight: 500;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity .2s ease, transform .2s ease;
+}
+.copy-toast.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
 /* Action cards in panel (See / Plot) */
 .panel-card {
     margin-top: 10px;

--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -1567,7 +1567,13 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sor
     font-family: var(--font-mono);
     font-size: .8rem;
     font-weight: 500;
-    word-break: break-all;
+    /* Let the host use the full (column-stacked) row width and only wrap when it
+       truly must - never break mid-token. break-all split hostnames like
+       "ytelse-tos.u|ninett.no". min-width:0 lets the flex item shrink so the
+       wrap happens inside the row instead of overflowing. */
+    min-width: 0;
+    word-break: normal;
+    overflow-wrap: anywhere;
 }
 
 /* Action cards in panel (See / Plot) */

--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -1541,13 +1541,22 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sor
 /* From/To endpoint display */
 .link-panel-endpoints {
     display: flex;
-    flex-direction: column;
-    gap: 6px;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
     margin-bottom: 12px;
     padding: 10px 12px;
     background: var(--c-elevated);
     border-radius: var(--r);
     border: 1px solid var(--c-border);
+}
+/* The two endpoints stack vertically; the swap button sits to their right. */
+.link-endpoint-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    flex: 1 1 auto;
+    min-width: 0;
 }
 
 .link-endpoint {
@@ -1575,6 +1584,12 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sor
     word-break: normal;
     overflow-wrap: anywhere;
 }
+/* Hostnames copy to the clipboard on double-click (the per-host copy buttons
+   were removed to declutter the row). */
+.link-endpoint { min-width: 0; }
+.link-host { cursor: pointer; }
+.link-host:hover { color: var(--c-accent); }
+.link-host.copied { color: var(--c-accent); }
 
 /* Action cards in panel (See / Plot) */
 .panel-card {

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -1539,6 +1539,7 @@ function _link_copy_delegate(e) {
     function _flash() {
         btn.classList.add('copied');
         setTimeout(function () { btn.classList.remove('copied'); }, 1100);
+        _show_copy_toast('Hostname copied to clipboard');
     }
     if (navigator.clipboard && navigator.clipboard.writeText) {
         navigator.clipboard.writeText(value).then(_flash, function () { _link_copy_fallback(value, _flash); });
@@ -1555,6 +1556,24 @@ function _link_copy_fallback(text, onDone) {
     ta.focus(); ta.select();
     try { document.execCommand('copy'); onDone && onDone(); } catch (_) {}
     document.body.removeChild(ta);
+}
+// Small transient toast (bottom-centre) confirming a copy. Singleton element,
+// reused so rapid copies don't stack; each call restarts the show/hide cycle.
+var _copyToastTimer = null;
+function _show_copy_toast(msg) {
+    var t = document.getElementById('copy-toast');
+    if (!t) {
+        t = document.createElement('div');
+        t.id = 'copy-toast';
+        t.className = 'copy-toast';
+        t.setAttribute('role', 'status');
+        t.setAttribute('aria-live', 'polite');
+        document.body.appendChild(t);
+    }
+    t.textContent = msg;
+    if (_copyToastTimer) clearTimeout(_copyToastTimer);
+    requestAnimationFrame(function () { t.classList.add('show'); });
+    _copyToastTimer = setTimeout(function () { t.classList.remove('show'); }, 1600);
 }
 $(document).on('click', '.link-copy-btn', _link_copy_delegate);
 $(document).on('dblclick', '.link-host', _link_copy_delegate);

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -1525,23 +1525,16 @@ function link_popup(link){
     return div;
 }
 
-// Small clipboard button rendered next to each hostname in the link
-// panel, so users can copy an FQDN straight into a ticket. One delegated
-// handler (wired below) serves every button via the .link-copy-btn class.
-function _link_copy_btn(val) {
-    var v = escapeHtml(String(val == null ? '' : val));
-    return '<button type="button" class="link-copy-btn" data-copy-value="' + v + '" title="Copy hostname" aria-label="Copy hostname">' +
-        '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">' +
-          '<rect x="9" y="9" width="13" height="13" rx="2"/>' +
-          '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>' +
-        '</svg></button>';
-}
+// Copy a hostname to the clipboard on double-click of its name in the link
+// panel (replaces the old per-host copy buttons, which crowded the row). One
+// delegated handler serves the .link-host spans (dblclick); it still also
+// accepts any .link-copy-btn (click) for backward compatibility.
 function _link_copy_delegate(e) {
-    var btn = e.target && e.target.closest && e.target.closest('.link-copy-btn');
+    var btn = e.target && e.target.closest && e.target.closest('.link-copy-btn, .link-host');
     if (!btn) return;
     e.preventDefault();
     e.stopPropagation();
-    var value = btn.dataset.copyValue || '';
+    var value = btn.dataset.copyValue || btn.textContent || '';
     if (!value) return;
     function _flash() {
         btn.classList.add('copied');
@@ -1564,6 +1557,7 @@ function _link_copy_fallback(text, onDone) {
     document.body.removeChild(ta);
 }
 $(document).on('click', '.link-copy-btn', _link_copy_delegate);
+$(document).on('dblclick', '.link-host', _link_copy_delegate);
 
 // Reverse the link panel: show the opposite-direction pair (to→from). Uses the
 // reverse summary record if the archive has one, else just relabels. Moves the
@@ -1600,8 +1594,10 @@ function make_tooltip_v2(fromHost, toHost, link){
     if (! jQuery.isEmptyObject(conffile)) {
 	var nrows=0;
 	var tip='<div class="link-panel-endpoints">';
-	tip += '<div class="link-endpoint"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg> <span>' + fromHost + '</span>' + _link_copy_btn(fromHost) + '</div>';
-	tip += '<div class="link-endpoint"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg> <span>' + toHost + '</span>' + _link_copy_btn(toHost) + '</div>';
+	tip += '<div class="link-endpoint-list">';
+	tip += '<div class="link-endpoint"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M12 2v4M12 18v4M4.93 4.93l2.83 2.83M16.24 16.24l2.83 2.83M2 12h4M18 12h4M4.93 19.07l2.83-2.83M16.24 7.76l2.83-2.83"/></svg> <span class="link-host" data-copy-value="' + escapeHtml(fromHost) + '" title="Double-click to copy">' + fromHost + '</span></div>';
+	tip += '<div class="link-endpoint"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12h14M12 5l7 7-7 7"/></svg> <span class="link-host" data-copy-value="' + escapeHtml(toHost) + '" title="Double-click to copy">' + toHost + '</span></div>';
+	tip += '</div>';
 	// Swap-direction button — only when the archive actually has the reverse
 	// pair to show (otherwise the swap would just relabel the same numbers).
 	var hasReverse = false;


### PR DESCRIPTION
Frontend polish for the link-details panel, plus asset cache-busting.

### Link details panel
- **Hostnames no longer break mid-token.** `word-break: break-all` split FQDNs like `ytelse-tos.u|ninett.no`; they now use the full row width and only wrap when truly necessary (`overflow-wrap: anywhere`). More noticeable since the vendored JetBrains Mono actually loads now (after the font 404 fix).
- **Swap-direction button moved to the right of the names** — the two endpoints stack in a `.link-endpoint-list` column and the reverse-direction button sits beside them (it used to be below).
- **Copy a hostname by double-clicking its name.** The per-host copy buttons were removed to declutter the row; double-clicking the FQDN copies it (hover hint + "Double-click to copy" tooltip). Frees row width too, so long names wrap less.
- **"Hostname copied to clipboard" toast** on copy (bottom-centre, theme-aware, singleton), in addition to the brief colour flash. Fired from the shared copy helper, so it covers the clipboard and fallback paths.

### Cache-busting
- `Cache-Control: no-cache` for the map's `*.html`/`*.js`/`*.css` in `apache-microdep-map.conf`, so a deployed change is picked up on a normal reload (the server answers 304 when unchanged, so it stays cheap). ES-module imports made per-file `?v=` versioning awkward, so a server-side revalidate header is the clean fix; fonts/images keep their default caching.

### Testing
JS syntax-checked (ES module), CSS balanced, `apache2ctl configtest` OK. Deployed to a test host: cache header verified (`Cache-Control: no-cache` on CSS, fonts unaffected), and the double-click copy + toast + new layout confirmed.