### PR TITLE
Show config help texts on the dropdown controls (#108)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/index.html
+++ b/microdep/perfsonar-microdep/microdep-map/index.html
@@ -443,9 +443,14 @@
           optionEl.className = 'custom-select-option';
           optionEl.dataset.value = opt.value;
           optionEl.innerHTML = checkIconSVG + '<span class="custom-select-option-text">' + opt.textContent + '</span>';
+          // Carry the native option's help text (the config `descr`, set as the
+          // option title by make_prop_select) onto the styled option, so hovering
+          // a menu item shows its description (issue #108).
+          if (opt.title) optionEl.title = opt.title;
           if (opt.selected) {
             optionEl.classList.add('selected');
             valueEl.textContent = opt.textContent;
+            if (opt.title) trigger.title = opt.title; else trigger.removeAttribute('title');
           }
           optionEl.addEventListener('click', function(e) {
             e.stopPropagation();
@@ -481,6 +486,8 @@
         var selectedOpt = nativeSelect.options[nativeSelect.selectedIndex];
         if (selectedOpt) {
           valueEl.textContent = selectedOpt.textContent;
+          // Keep the selectbox's hover help text in sync with the selection (#108).
+          if (selectedOpt.title) trigger.title = selectedOpt.title; else trigger.removeAttribute('title');
           dropdown.querySelectorAll('.custom-select-option').forEach(function(opt) {
             opt.classList.toggle('selected', opt.dataset.value === selectedOpt.value);
           });


### PR DESCRIPTION
Resolves #108 (reported by @ottojwittner).

### Symptom
Mouse-over help texts (the `descr` values from `mapconfig.yml` / `mapconfig.d/*`, loaded into the `*_long_desc` structures) never appeared on the network / event-type / property controls.

### Cause
`make_prop_select()` sets each native `<option>`'s `title` to its config description, but those dropdowns are rendered as **styled custom-selects**. The custom-select builder rebuilt the option items (and the trigger showing the selected value) **without copying the option `title`**, so the help text was there on the hidden native `<select>` but never on the visible control.

### Fix (`index.html`, custom-select builder)
- Copy the native option's `title` onto each styled dropdown item.
- Set the trigger's `title` to the selected option's description, and keep it in sync on change.

Descriptions now show on hover for net / events / properties wherever the config provides one (menu items and the selected value alike).

### Testing
Inline JS syntax-checked; data path confirmed (config `descr` → `*_long_desc` → `option.title` → styled item). Deployed to a test host — wants a quick hover check that the tooltips appear.

Closes #108