### PR TITLE
Self-heal the OpenSearch read grant (recurring map + Grafana "No Data")

### DIFF
--- a/microdep/perfsonar-microdep/bin/microdep_commands/microdep-opensearch-guard.sh
+++ b/microdep/perfsonar-microdep/bin/microdep_commands/microdep-opensearch-guard.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+#
+# microdep-opensearch-guard.sh
+#
+# Self-heal the Microdep OpenSearch read grant.
+#
+# The Microdep map (via the CGIs) and the Grafana dashboards read the archive
+# ANONYMOUSLY through https://localhost/opensearch. Read access to the Microdep
+# indices (dragonlab* / microdep*) is granted by inserting roles_yml_patch into
+# the perfSONAR OpenSearch role config; opensearch_config_microdep.sh does that
+# at package install time.
+#
+# A perfSONAR/OpenSearch UPGRADE re-initialises /etc/opensearch/opensearch-
+# security/roles.yml (and reloads it via securityadmin) WITHOUT the Microdep
+# patch, so the grant silently disappears until Microdep is re-installed. The
+# symptom: the map and every Grafana Microdep panel report "No Data" because the
+# archive answers HTTP 403 ("no permissions ... opendistro_security_anonymous").
+#
+# This guard probes anonymous read on a Microdep index and, ONLY if it is denied
+# (403), re-applies the config via opensearch_config_microdep.sh. It is a no-op
+# when the grant is present, and skips quietly when the archive is unreachable
+# (e.g. OpenSearch restarting). Run it from a systemd timer.
+#
+# Exit status is always 0 (best-effort healer); actions are logged to syslog
+# under the tag "microdep-opensearch-guard".
+
+set -u
+
+PROBE_URL="${MICRODEP_PROBE_URL:-https://localhost/opensearch/dragonlab/_count}"
+CONFIG_SCRIPT="${MICRODEP_CONFIG_SCRIPT:-/usr/lib/perfsonar/bin/microdep_commands/opensearch_config_microdep.sh}"
+TAG="microdep-opensearch-guard"
+
+log() { logger -t "$TAG" -- "$*" 2>/dev/null || echo "$TAG: $*" >&2; }
+
+probe() { curl -s -k -o /dev/null -w '%{http_code}' --max-time 15 "$PROBE_URL" 2>/dev/null; }
+
+code=$(probe)
+
+case "$code" in
+    200)
+        # Grant present — nothing to do.
+        exit 0
+        ;;
+    403)
+        log "anonymous read on Microdep index denied (HTTP 403) — re-applying grant"
+        if [ ! -x "$CONFIG_SCRIPT" ]; then
+            log "ERROR: $CONFIG_SCRIPT missing or not executable — cannot heal"
+            exit 0
+        fi
+        if "$CONFIG_SCRIPT" -y -q >/dev/null 2>&1; then
+            newcode=$(probe)
+            if [ "$newcode" = "200" ]; then
+                log "grant restored (read now returns HTTP 200)"
+            else
+                log "re-apply ran but read still returns HTTP ${newcode:-?}"
+            fi
+        else
+            log "ERROR: $CONFIG_SCRIPT exited non-zero"
+        fi
+        ;;
+    000|"")
+        # Archive not reachable (OpenSearch/apache down or restarting). Don't
+        # thrash — the next timer tick will retry.
+        log "archive not reachable (curl code ${code:-none}) — skipping this cycle"
+        ;;
+    *)
+        # Some other status (e.g. 5xx). Not a permission problem we should fix by
+        # re-applying roles; leave it and log for visibility.
+        log "unexpected HTTP $code from archive probe — skipping (not a 403)"
+        ;;
+esac
+
+exit 0

--- a/microdep/perfsonar-microdep/scripts/perfsonar-microdep-opensearch-guard.service
+++ b/microdep/perfsonar-microdep/scripts/perfsonar-microdep-opensearch-guard.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Re-apply the Microdep OpenSearch read grant if a perfSONAR/OpenSearch upgrade reset it
+After=network-online.target opensearch.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/perfsonar/bin/microdep_commands/microdep-opensearch-guard.sh
+Nice=10

--- a/microdep/perfsonar-microdep/scripts/perfsonar-microdep-opensearch-guard.timer
+++ b/microdep/perfsonar-microdep/scripts/perfsonar-microdep-opensearch-guard.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Periodically ensure the Microdep OpenSearch read grant is present
+
+[Timer]
+# A few minutes after boot, then every 15 minutes. Persistent catches up a
+# missed run after downtime. So a grant wiped by an upgrade is restored within
+# ~15 min automatically.
+OnBootSec=3min
+OnUnitActiveSec=15min
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/microdep/perfsonar-microdep/unibuild-packaging/deb/perfsonar-microdep-logstash.install
+++ b/microdep/perfsonar-microdep/unibuild-packaging/deb/perfsonar-microdep-logstash.install
@@ -1,5 +1,6 @@
 etc/logstash/microdep/* usr/lib/perfsonar/logstash/microdep_pipeline/
 bin/microdep_commands/opensearch_config_microdep.sh usr/lib/perfsonar/bin/microdep_commands/
+bin/microdep_commands/microdep-opensearch-guard.sh usr/lib/perfsonar/bin/microdep_commands/
 bin/microdep_commands/psconfig_archive_ana.sh usr/lib/perfsonar/bin/microdep_commands/
 etc/logrotate.d/microdep etc/logrotate.d/
 etc/apache-microdep-ana.conf etc/apache2/conf-available/

--- a/microdep/perfsonar-microdep/unibuild-packaging/deb/perfsonar-microdep-logstash.perfsonar-microdep-opensearch-guard.service
+++ b/microdep/perfsonar-microdep/unibuild-packaging/deb/perfsonar-microdep-logstash.perfsonar-microdep-opensearch-guard.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Re-apply the Microdep OpenSearch read grant if a perfSONAR/OpenSearch upgrade reset it
+After=network-online.target opensearch.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/perfsonar/bin/microdep_commands/microdep-opensearch-guard.sh
+Nice=10

--- a/microdep/perfsonar-microdep/unibuild-packaging/deb/perfsonar-microdep-logstash.perfsonar-microdep-opensearch-guard.timer
+++ b/microdep/perfsonar-microdep/unibuild-packaging/deb/perfsonar-microdep-logstash.perfsonar-microdep-opensearch-guard.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Periodically ensure the Microdep OpenSearch read grant is present
+
+[Timer]
+# A few minutes after boot, then every 15 minutes. Persistent catches up a
+# missed run after downtime. So a grant wiped by an upgrade is restored within
+# ~15 min automatically.
+OnBootSec=3min
+OnUnitActiveSec=15min
+RandomizedDelaySec=60
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/microdep/perfsonar-microdep/unibuild-packaging/rpm/perfsonar-microdep.spec
+++ b/microdep/perfsonar-microdep/unibuild-packaging/rpm/perfsonar-microdep.spec
@@ -352,8 +352,14 @@ systemctl start perfsonar-microdep-restart.timer || true
 systemctl start perfsonar-microdep-hourly-aggregator.timer || true
 
 %post logstash
-# Add Microdep to Opensearch setup (including Logstash) 
+# Add Microdep to Opensearch setup (including Logstash)
 /usr/lib/perfsonar/bin/microdep_commands/opensearch_config_microdep.sh || true
+
+# Self-heal timer: re-apply the OpenSearch read grant if a perfSONAR/OpenSearch
+# upgrade later resets roles.yml and drops it.
+systemctl daemon-reload || true
+systemctl enable perfsonar-microdep-opensearch-guard.timer || true
+systemctl start perfsonar-microdep-opensearch-guard.timer || true
 
 if [ ! -f /etc/perfsonar/microdep/microdep-ana-archive.json ]; then
     # Prepare default logstash archive config for analytic results
@@ -398,7 +404,10 @@ systemctl stop perfsonar-microdep-restart.timer || true
 systemctl stop perfsonar-microdep-hourly-aggregator.timer || true
 
 %preun logstash
-# Remove Microdep from Opensearch setup (including Logstash) 
+# Stop the OpenSearch read-grant self-heal timer
+systemctl stop perfsonar-microdep-opensearch-guard.timer || true
+systemctl disable perfsonar-microdep-opensearch-guard.timer || true
+# Remove Microdep from Opensearch setup (including Logstash)
 /usr/lib/perfsonar/bin/microdep_commands/opensearch_config_microdep.sh -r config || true
 
 %preun map
@@ -461,6 +470,9 @@ systemctl reload httpd.service || true
 %defattr(0644,perfsonar,perfsonar,0755)
 %license %{doc_base}/LICENSE-logstash
 %attr(0755,perfsonar,perfsonar) %{command_base}/opensearch_config_microdep.sh
+%attr(0755,perfsonar,perfsonar) %{command_base}/microdep-opensearch-guard.sh
+%{_unitdir}/perfsonar-microdep-opensearch-guard.service
+%{_unitdir}/perfsonar-microdep-opensearch-guard.timer
 %attr(0755,perfsonar,perfsonar) %{command_base}/psconfig_archive_ana.sh
 /usr/local/bin/psconfig_archive_ana.sh
 /usr/local/bin/opensearch_config_microdep.sh
@@ -478,6 +490,9 @@ systemctl reload httpd.service || true
 %defattr(0644,perfsonar,perfsonar,0755)
 %license %{doc_base}/LICENSE-logstash
 %attr(0755,perfsonar,perfsonar) %{command_base}/opensearch_config_microdep.sh
+%attr(0755,perfsonar,perfsonar) %{command_base}/microdep-opensearch-guard.sh
+%{_unitdir}/perfsonar-microdep-opensearch-guard.service
+%{_unitdir}/perfsonar-microdep-opensearch-guard.timer
 %attr(0755,perfsonar,perfsonar) %{command_base}/psconfig_archive_ana.sh
 /usr/local/bin/psconfig_archive_ana.sh
 /usr/local/bin/opensearch_config_microdep.sh


### PR DESCRIPTION
### Problem
The Microdep map (via the CGIs) and the Grafana dashboards read the archive **anonymously** through `https://localhost/opensearch`. Read access to the Microdep indices (`dragonlab*` / `microdep*`) comes from `etc/roles_yml_patch`, which `opensearch_config_microdep.sh` inserts into perfSONAR's OpenSearch `roles.yml` at install.

A **perfSONAR/OpenSearch upgrade re-initialises `roles.yml` without that patch**, so the grant silently disappears and *everything* reports **"No Data"** — the archive answers HTTP 403 (`no permissions … opendistro_security_anonymous`). This actually happened on the test host after ~6 weeks: map and all Grafana Microdep panels went blank while the data was still there. (`pscheduler*` kept working, which is the tell.)

### Fix — self-healing timer
- `bin/microdep_commands/microdep-opensearch-guard.sh` — probes anonymous read on a Microdep index and re-applies the config **only** when it gets a 403 (no-op otherwise; skips quietly when OpenSearch is unreachable). Best-effort, logs to syslog.
- `scripts/perfsonar-microdep-opensearch-guard.{service,timer}` — runs it a few minutes after boot and every 15 min, so a wiped grant self-heals within ~15 min with no reinstall.
- Wired into the **logstash** package (deb + rpm): installs the script + units, enables/starts the timer; deb removal handled by `dh`, rpm `%preun` stops it.

### Testing
`bash -n` clean. Deployed + enabled on a test host: timer active, ran once as a clean no-op, and the manual `opensearch_config_microdep.sh -y` restored access (dragonlab readable again, map + Grafana back).

> Reviewer note: touches OpenSearch security (re-applies the anonymous grant) and packaging — worth a check by whoever builds the deb/rpm, since I can't build the packages here.