### PR TITLE
Native Grafana dashboards for Microdep (Gaps overview, Map, Details)

### DIFF
--- a/microdep/perfsonar-microdep/etc/grafana/README.md
+++ b/microdep/perfsonar-microdep/etc/grafana/README.md
@@ -12,10 +12,12 @@ button injected into the perfSONAR main dashboard) — it does not replace it.
 
 | File | Purpose | Provision to |
 |------|---------|--------------|
-| `microdep-datasource.yaml`        | OpenSearch datasource for the `dragonlab` index | `…/grafana/provisioning/datasources/` |
+| `microdep-datasource.yaml`        | OpenSearch datasource for the `dragonlab` index (gap) | `…/grafana/provisioning/datasources/` |
+| `microdep-jitter-datasource.yaml` | OpenSearch datasource for the `dragonlab_jitter` index (Queues/jitter) | `…/grafana/provisioning/datasources/` |
 | `microdep-dashboards.yaml`        | Dashboard provider (loads the `dashboards/` dir into a "Microdep" folder) | `…/grafana/provisioning/dashboards/` |
 | `dashboards/microdep-gaps.json`   | Native dashboard: total gaps (stat), gaps over time, top-10 source hosts, map button | `…/grafana/dashboards/microdep/` |
 | `dashboards/microdep-map.json`    | The geographic map embedded full-size as an `<iframe>` to `/microdep/` | `…/grafana/dashboards/microdep/` |
+| `dashboards/microdep-details.json`| Native dashboard: jitter percentiles over time, top link pairs by time-lost, source×target gap matrix (`esnet-matrix-panel`), gap/jitter data-freshness stats | `…/grafana/dashboards/microdep/` |
 
 On a perfSONAR host the provisioning root is `/usr/lib/perfsonar/grafana/provisioning`
 (`grafana.ini` → `[paths] provisioning`).
@@ -23,11 +25,13 @@ On a perfSONAR host the provisioning root is `/usr/lib/perfsonar/grafana/provisi
 ## Provision (manual, for testing)
 
 ```sh
-install -m640 microdep-datasource.yaml  /usr/lib/perfsonar/grafana/provisioning/datasources/
-install -m640 microdep-dashboards.yaml  /usr/lib/perfsonar/grafana/provisioning/dashboards/
-install -d                              /usr/lib/perfsonar/grafana/dashboards/microdep
-install -m644 dashboards/microdep-gaps.json /usr/lib/perfsonar/grafana/dashboards/microdep/
-install -m644 dashboards/microdep-map.json  /usr/lib/perfsonar/grafana/dashboards/microdep/
+install -m640 microdep-datasource.yaml         /usr/lib/perfsonar/grafana/provisioning/datasources/
+install -m640 microdep-jitter-datasource.yaml  /usr/lib/perfsonar/grafana/provisioning/datasources/
+install -m640 microdep-dashboards.yaml         /usr/lib/perfsonar/grafana/provisioning/dashboards/
+install -d                                     /usr/lib/perfsonar/grafana/dashboards/microdep
+install -m644 dashboards/microdep-gaps.json    /usr/lib/perfsonar/grafana/dashboards/microdep/
+install -m644 dashboards/microdep-map.json     /usr/lib/perfsonar/grafana/dashboards/microdep/
+install -m644 dashboards/microdep-details.json /usr/lib/perfsonar/grafana/dashboards/microdep/
 systemctl restart grafana-server
 ```
 

--- a/microdep/perfsonar-microdep/etc/grafana/README.md
+++ b/microdep/perfsonar-microdep/etc/grafana/README.md
@@ -14,7 +14,8 @@ button injected into the perfSONAR main dashboard) — it does not replace it.
 |------|---------|--------------|
 | `microdep-datasource.yaml`        | OpenSearch datasource for the `dragonlab` index | `…/grafana/provisioning/datasources/` |
 | `microdep-dashboards.yaml`        | Dashboard provider (loads the `dashboards/` dir into a "Microdep" folder) | `…/grafana/provisioning/dashboards/` |
-| `dashboards/microdep-gaps.json`   | Starter dashboard: total gaps (stat), gaps over time, top-10 source hosts, map button | `…/grafana/dashboards/microdep/` |
+| `dashboards/microdep-gaps.json`   | Native dashboard: total gaps (stat), gaps over time, top-10 source hosts, map button | `…/grafana/dashboards/microdep/` |
+| `dashboards/microdep-map.json`    | The geographic map embedded full-size as an `<iframe>` to `/microdep/` | `…/grafana/dashboards/microdep/` |
 
 On a perfSONAR host the provisioning root is `/usr/lib/perfsonar/grafana/provisioning`
 (`grafana.ini` → `[paths] provisioning`).
@@ -26,6 +27,7 @@ install -m640 microdep-datasource.yaml  /usr/lib/perfsonar/grafana/provisioning/
 install -m640 microdep-dashboards.yaml  /usr/lib/perfsonar/grafana/provisioning/dashboards/
 install -d                              /usr/lib/perfsonar/grafana/dashboards/microdep
 install -m644 dashboards/microdep-gaps.json /usr/lib/perfsonar/grafana/dashboards/microdep/
+install -m644 dashboards/microdep-map.json  /usr/lib/perfsonar/grafana/dashboards/microdep/
 systemctl restart grafana-server
 ```
 
@@ -37,6 +39,10 @@ Then open Grafana → Dashboards → **Microdep / Microdep — Gaps overview**.
   epoch `float` and `datetime` is `text` — neither works as a Grafana time
   field or in `date_histogram`.
 - **Term aggregations need `.keyword`** (e.g. `from.keyword`).
+- **The embedded map** (`microdep-map.json`) relies on `[panels]
+  disable_sanitize_html = true` in `grafana.ini` (so the Text panel keeps the
+  `<iframe>`) and on `/microdep/` not sending a blocking `X-Frame-Options` /
+  CSP `frame-ancestors` (it is same-origin with Grafana, so it frames fine).
 - The datasource mirrors perfSONAR's own `perfsonar-local.yaml` (proxy access,
   `tlsSkipVerify`, flavor `opensearch`) but targets the `dragonlab` index with a
   distinct uid `microdep-dragonlab`, so it sits alongside the pscheduler one.

--- a/microdep/perfsonar-microdep/etc/grafana/README.md
+++ b/microdep/perfsonar-microdep/etc/grafana/README.md
@@ -1,0 +1,56 @@
+# Native Grafana panels for Microdep (starter)
+
+A proof-of-concept showing the **hybrid** Grafana integration: tabular /
+statistical / time-series views rendered **natively** in Grafana (querying the
+same OpenSearch archive directly), while the geographic topology map stays the
+custom app at `/microdep/` (linked from a panel).
+
+This complements the existing `etc/grafana_dashboard_patch` (a "Microdep map"
+button injected into the perfSONAR main dashboard) — it does not replace it.
+
+## Files
+
+| File | Purpose | Provision to |
+|------|---------|--------------|
+| `microdep-datasource.yaml`        | OpenSearch datasource for the `dragonlab` index | `…/grafana/provisioning/datasources/` |
+| `microdep-dashboards.yaml`        | Dashboard provider (loads the `dashboards/` dir into a "Microdep" folder) | `…/grafana/provisioning/dashboards/` |
+| `dashboards/microdep-gaps.json`   | Starter dashboard: total gaps (stat), gaps over time, top-10 source hosts, map button | `…/grafana/dashboards/microdep/` |
+
+On a perfSONAR host the provisioning root is `/usr/lib/perfsonar/grafana/provisioning`
+(`grafana.ini` → `[paths] provisioning`).
+
+## Provision (manual, for testing)
+
+```sh
+install -m640 microdep-datasource.yaml  /usr/lib/perfsonar/grafana/provisioning/datasources/
+install -m640 microdep-dashboards.yaml  /usr/lib/perfsonar/grafana/provisioning/dashboards/
+install -d                              /usr/lib/perfsonar/grafana/dashboards/microdep
+install -m644 dashboards/microdep-gaps.json /usr/lib/perfsonar/grafana/dashboards/microdep/
+systemctl restart grafana-server
+```
+
+Then open Grafana → Dashboards → **Microdep / Microdep — Gaps overview**.
+
+## Notes / gotchas
+
+- **Time field is `@timestamp`** (type `date`). The `timestamp` field is an
+  epoch `float` and `datetime` is `text` — neither works as a Grafana time
+  field or in `date_histogram`.
+- **Term aggregations need `.keyword`** (e.g. `from.keyword`).
+- The datasource mirrors perfSONAR's own `perfsonar-local.yaml` (proxy access,
+  `tlsSkipVerify`, flavor `opensearch`) but targets the `dragonlab` index with a
+  distinct uid `microdep-dragonlab`, so it sits alongside the pscheduler one.
+
+## Possible extensions
+
+- **Per-link** table (from→to) via nested terms / multi-terms aggregation.
+- **Severity** columns (avg/max `down_ppm`, time lost) once field names are
+  confirmed against the gap mapping.
+- **Other event types**: jitter ("Queues", index `dragonlab_jitter`,
+  percentile metrics), route changes (`dragonlab_routemon`) — likely a second
+  datasource per index, or an index-pattern datasource.
+- **Multi-network**: Net-4 (`dragonlab`) vs Net-6 (`dragonlab_6`) as a
+  datasource template variable (`${ds}`), the pattern perfSONAR dashboards use.
+- **Heatmap** report natively via the installed `esnet-matrix-panel`.
+- **Packaging**: wire these into the deb/rpm post-install the way
+  `grafana_dashboard_patch` is, once the approach is agreed.

--- a/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-details.json
+++ b/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-details.json
@@ -127,7 +127,7 @@
           { "matcher": { "id": "byName", "options": "Sum" }, "properties": [ { "id": "displayName", "value": "Time lost (ms)" }, { "id": "unit", "value": "ms" } ] }
         ]
       },
-      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 8 },
+      "gridPos": { "h": 16, "w": 14, "x": 0, "y": 8 },
       "id": 4,
       "options": {
         "cellHeight": "sm",
@@ -159,7 +159,7 @@
       "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
       "description": "Source x target matrix coloured by gap-event count over the selected range.",
       "fieldConfig": { "defaults": { "color": { "mode": "continuous-YlRd" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
-      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 8 },
+      "gridPos": { "h": 16, "w": 10, "x": 14, "y": 8 },
       "id": 5,
       "options": {
         "sourceField": "from.keyword",
@@ -170,10 +170,10 @@
         "valueText": "Gaps",
         "showLegend": true,
         "legendType": "range",
-        "cellSize": 26,
-        "cellPadding": 2,
-        "txtLength": 16,
-        "txtSize": 11
+        "cellSize": 46,
+        "cellPadding": 3,
+        "txtLength": 18,
+        "txtSize": 12
       },
       "pluginVersion": "2.0.0",
       "targets": [

--- a/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-details.json
+++ b/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-details.json
@@ -1,0 +1,210 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-jitter" },
+      "description": "Jitter (h_jit) 50th/95th/99th percentile over time, from the dense dragonlab_jitter index.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false, "axisCenteredZero": false, "axisColorMode": "text",
+            "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line",
+            "fillOpacity": 10, "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "smooth", "lineWidth": 2, "pointSize": 5,
+            "scaleDistribution": { "type": "linear" }, "showPoints": "never", "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 16, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "pluginVersion": "11.6.10",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-jitter" },
+          "query": "",
+          "queryType": "lucene",
+          "alias": "",
+          "metrics": [ { "id": "1", "type": "percentiles", "field": "h_jit", "settings": { "percents": [ "50", "95", "99" ] } } ],
+          "bucketAggs": [ { "id": "2", "type": "date_histogram", "field": "@timestamp", "settings": { "interval": "auto", "min_doc_count": "0" } } ],
+          "timeField": "@timestamp",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "title": "Jitter percentiles over time (h_jit, ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+      "description": "Most recent gap event timestamp in the selected range — is gap data flowing?",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "text" }, "mappings": [], "unit": "dateTimeFromNow" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "none", "graphMode": "none", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "11.6.10",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+          "query": "event_type:gap",
+          "queryType": "lucene",
+          "alias": "",
+          "metrics": [ { "id": "1", "type": "max", "field": "@timestamp" } ],
+          "bucketAggs": [ { "id": "2", "type": "date_histogram", "field": "@timestamp", "settings": { "interval": "auto", "min_doc_count": "0" } } ],
+          "timeField": "@timestamp",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Gap data — last seen",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-jitter" },
+      "description": "Most recent jitter sample timestamp in the selected range — is jitter data flowing?",
+      "fieldConfig": {
+        "defaults": { "color": { "mode": "fixed", "fixedColor": "text" }, "mappings": [], "unit": "dateTimeFromNow" },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 4 },
+      "id": 3,
+      "options": {
+        "colorMode": "none", "graphMode": "none", "justifyMode": "auto", "orientation": "auto",
+        "reduceOptions": { "calcs": [ "lastNotNull" ], "fields": "", "values": false },
+        "textMode": "value"
+      },
+      "pluginVersion": "11.6.10",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-jitter" },
+          "query": "",
+          "queryType": "lucene",
+          "alias": "",
+          "metrics": [ { "id": "1", "type": "max", "field": "@timestamp" } ],
+          "bucketAggs": [ { "id": "2", "type": "date_histogram", "field": "@timestamp", "settings": { "interval": "auto", "min_doc_count": "0" } } ],
+          "timeField": "@timestamp",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Jitter data — last seen",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+      "description": "Link pairs with the most lost time (sum of tloss, ms). Click a column header to sort.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "filterable": true, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "from.keyword" }, "properties": [ { "id": "displayName", "value": "Source" } ] },
+          { "matcher": { "id": "byName", "options": "to.keyword" }, "properties": [ { "id": "displayName", "value": "Target" } ] },
+          { "matcher": { "id": "byName", "options": "Sum" }, "properties": [ { "id": "displayName", "value": "Time lost (ms)" }, { "id": "unit", "value": "ms" } ] }
+        ]
+      },
+      "gridPos": { "h": 12, "w": 12, "x": 0, "y": 8 },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": [ "sum" ], "show": false },
+        "showHeader": true,
+        "sortBy": [ { "desc": true, "displayName": "Time lost (ms)" } ]
+      },
+      "pluginVersion": "11.6.10",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+          "query": "event_type:gap",
+          "queryType": "lucene",
+          "alias": "",
+          "metrics": [ { "id": "1", "type": "sum", "field": "tloss" } ],
+          "bucketAggs": [
+            { "id": "2", "type": "terms", "field": "from.keyword", "settings": { "size": "25", "orderBy": "1", "order": "desc", "min_doc_count": "1" } },
+            { "id": "3", "type": "terms", "field": "to.keyword", "settings": { "size": "25", "orderBy": "1", "order": "desc", "min_doc_count": "1" } }
+          ],
+          "timeField": "@timestamp",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Top link pairs by time lost",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+      "description": "Source x target matrix coloured by gap-event count over the selected range.",
+      "fieldConfig": { "defaults": { "color": { "mode": "continuous-YlRd" }, "mappings": [], "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }, "unit": "short" }, "overrides": [] },
+      "gridPos": { "h": 12, "w": 12, "x": 12, "y": 8 },
+      "id": 5,
+      "options": {
+        "sourceField": "from.keyword",
+        "targetField": "to.keyword",
+        "valueField": "Count",
+        "sourceText": "Source",
+        "targetText": "Target",
+        "valueText": "Gaps",
+        "showLegend": true,
+        "legendType": "range",
+        "cellSize": 26,
+        "cellPadding": 2,
+        "txtLength": 16,
+        "txtSize": 11
+      },
+      "pluginVersion": "2.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+          "query": "event_type:gap",
+          "queryType": "lucene",
+          "alias": "",
+          "metrics": [ { "id": "1", "type": "count" } ],
+          "bucketAggs": [
+            { "id": "2", "type": "terms", "field": "from.keyword", "settings": { "size": "50", "orderBy": "_term", "order": "asc", "min_doc_count": "1" } },
+            { "id": "3", "type": "terms", "field": "to.keyword", "settings": { "size": "50", "orderBy": "_term", "order": "asc", "min_doc_count": "1" } }
+          ],
+          "timeField": "@timestamp",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Gap matrix (source x target, by count)",
+      "type": "esnet-matrix-panel"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [ "microdep" ],
+  "templating": { "list": [] },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Microdep — Details",
+  "uid": "microdep-details",
+  "version": 1,
+  "weekStart": ""
+}

--- a/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-gaps.json
+++ b/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-gaps.json
@@ -1,0 +1,164 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+      "description": "Total number of gap events in the selected time range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null }, { "color": "red", "value": 1 } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 6, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": [ "sum" ], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "11.6.10",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+          "query": "event_type:gap",
+          "queryType": "lucene",
+          "alias": "",
+          "metrics": [ { "id": "1", "type": "count" } ],
+          "bucketAggs": [ { "id": "2", "type": "date_histogram", "field": "@timestamp", "settings": { "interval": "auto", "min_doc_count": "0" } } ],
+          "timeField": "@timestamp",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "title": "Total gap events",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+      "description": "Gap events per time bucket.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 7, "w": 18, "x": 6, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "pluginVersion": "11.6.10",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+          "query": "event_type:gap",
+          "queryType": "lucene",
+          "alias": "gaps",
+          "metrics": [ { "id": "1", "type": "count" } ],
+          "bucketAggs": [ { "id": "2", "type": "date_histogram", "field": "@timestamp", "settings": { "interval": "auto", "min_doc_count": "0" } } ],
+          "timeField": "@timestamp",
+          "format": "time_series",
+          "refId": "A"
+        }
+      ],
+      "title": "Gap events over time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+      "description": "Source hosts with the most gap events in the selected range. Click 'Open Microdep map' for the geographic view.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "filterable": true, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [ { "color": "green", "value": null } ] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 11, "w": 16, "x": 0, "y": 7 },
+      "id": 3,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": [ "sum" ], "show": false },
+        "showHeader": true,
+        "sortBy": [ { "desc": true, "displayName": "Count" } ]
+      },
+      "pluginVersion": "11.6.10",
+      "targets": [
+        {
+          "datasource": { "type": "grafana-opensearch-datasource", "uid": "microdep-dragonlab" },
+          "query": "event_type:gap",
+          "queryType": "lucene",
+          "alias": "",
+          "metrics": [ { "id": "1", "type": "count" } ],
+          "bucketAggs": [ { "id": "2", "type": "terms", "field": "from.keyword", "settings": { "order": "desc", "orderBy": "_count", "size": "10", "min_doc_count": "1" } } ],
+          "timeField": "@timestamp",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Top 10 source hosts by gap events",
+      "type": "table"
+    },
+    {
+      "description": "Link to the full geographic Microdep map (curved directional links, real-locations, etc.) which stays a custom view.",
+      "gridPos": { "h": 5, "w": 8, "x": 16, "y": 7 },
+      "id": 4,
+      "options": {
+        "code": { "language": "plaintext", "showLineNumbers": false, "showMiniMap": false },
+        "content": "<div class=\"nav-div\">\n<a class=\"simple-button\" target=\"_blank\" href=\"/microdep/\">Open Microdep map</a>\n</div>\n\n<style>\n  .nav-div { margin:18px 10px; text-align:center; }\n  .simple-button { display:inline-block; padding:10px 18px; border-radius:6px; background:#3274d9; color:#fff; text-decoration:none; font-weight:600; }\n</style>",
+        "mode": "html"
+      },
+      "pluginVersion": "11.6.10",
+      "title": "Microdep map",
+      "type": "text"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [ "microdep" ],
+  "templating": { "list": [] },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Microdep — Gaps overview",
+  "uid": "microdep-gaps",
+  "version": 1,
+  "weekStart": ""
+}

--- a/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-map.json
+++ b/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-map.json
@@ -1,0 +1,48 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Open full map in new tab",
+      "tooltip": "",
+      "type": "link",
+      "url": "/microdep/"
+    }
+  ],
+  "panels": [
+    {
+      "description": "The full geographic Microdep map embedded from /microdep/. It keeps all of its own controls (network, event type, date, period) and interactivity (curved directional links, popups, real-locations).",
+      "gridPos": { "h": 28, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "code": { "language": "html", "showLineNumbers": false, "showMiniMap": false },
+        "content": "<div style=\"position:relative;width:100%;height:88vh;min-height:480px;\">\n  <iframe src=\"/microdep/\" title=\"Microdep map\" loading=\"lazy\"\n          style=\"position:absolute;inset:0;width:100%;height:100%;border:0;border-radius:6px;\"></iframe>\n</div>",
+        "mode": "html"
+      },
+      "pluginVersion": "11.6.10",
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 39,
+  "tags": [ "microdep" ],
+  "templating": { "list": [] },
+  "time": { "from": "now-7d", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Microdep — Map",
+  "uid": "microdep-map",
+  "version": 1,
+  "weekStart": ""
+}

--- a/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-map.json
+++ b/microdep/perfsonar-microdep/etc/grafana/dashboards/microdep-map.json
@@ -21,11 +21,11 @@
   "panels": [
     {
       "description": "The full geographic Microdep map embedded from /microdep/. It keeps all of its own controls (network, event type, date, period) and interactivity (curved directional links, popups, real-locations).",
-      "gridPos": { "h": 28, "w": 24, "x": 0, "y": 0 },
+      "gridPos": { "h": 32, "w": 24, "x": 0, "y": 0 },
       "id": 1,
       "options": {
         "code": { "language": "html", "showLineNumbers": false, "showMiniMap": false },
-        "content": "<div style=\"position:relative;width:100%;height:88vh;min-height:480px;\">\n  <iframe src=\"/microdep/\" title=\"Microdep map\" loading=\"lazy\"\n          style=\"position:absolute;inset:0;width:100%;height:100%;border:0;border-radius:6px;\"></iframe>\n</div>",
+        "content": "<iframe src=\"/microdep/\" title=\"Microdep map\" style=\"position:absolute;inset:0;width:100%;height:100%;border:0;border-radius:6px;\"></iframe>",
         "mode": "html"
       },
       "pluginVersion": "11.6.10",

--- a/microdep/perfsonar-microdep/etc/grafana/microdep-dashboards.yaml
+++ b/microdep/perfsonar-microdep/etc/grafana/microdep-dashboards.yaml
@@ -1,0 +1,18 @@
+# Loads the native Microdep dashboards from disk into a "Microdep" folder.
+#
+# Provision by copying to:
+#   /usr/lib/perfsonar/grafana/provisioning/dashboards/
+# and placing the dashboard JSON files under the `path` below.
+apiVersion: 1
+
+providers:
+  - name: microdep
+    orgId: 1
+    folder: Microdep
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      foldersFromFilesStructure: false
+      path: /usr/lib/perfsonar/grafana/dashboards/microdep

--- a/microdep/perfsonar-microdep/etc/grafana/microdep-datasource.yaml
+++ b/microdep/perfsonar-microdep/etc/grafana/microdep-datasource.yaml
@@ -1,0 +1,35 @@
+# OpenSearch datasource for the Microdep `dragonlab` index (Net-4).
+#
+# Mirrors perfSONAR's own perfsonar-local.yaml, but points at the dragonlab
+# index instead of pscheduler*, and uses @timestamp as the time field.
+#   - @timestamp : date           <- use this
+#   - timestamp  : float (epoch)  <- NOT a date type, unusable as time field
+#   - datetime   : text           <- NOT a date type
+#
+# Provision by copying to:
+#   /usr/lib/perfsonar/grafana/provisioning/datasources/
+# (that path is grafana.ini's `provisioning` dir on a perfSONAR host).
+apiVersion: 1
+
+deleteDatasources:
+  - name: Microdep dragonlab
+    orgId: 1
+
+datasources:
+  - name: Microdep dragonlab
+    type: grafana-opensearch-datasource
+    access: proxy
+    orgId: 1
+    uid: microdep-dragonlab
+    url: https://localhost/opensearch
+    basicAuth: false
+    isDefault: false
+    jsonData:
+      database: "dragonlab"
+      flavor: "opensearch"
+      version: "2.6.0"
+      timeField: "@timestamp"
+      maxConcurrentShardRequests: 5
+      pplEnabled: true
+      tlsAuth: false
+      tlsSkipVerify: true

--- a/microdep/perfsonar-microdep/etc/grafana/microdep-jitter-datasource.yaml
+++ b/microdep/perfsonar-microdep/etc/grafana/microdep-jitter-datasource.yaml
@@ -1,0 +1,30 @@
+# OpenSearch datasource for the Microdep `dragonlab_jitter` index (the dense
+# "Queues"/jitter event). Separate from the dragonlab (gap) datasource because
+# the OpenSearch datasource binds one index pattern per datasource.
+# Time field is @timestamp (date); h_jit / h_ddelay / h_min_d are floats (ms).
+#
+# Provision to: /usr/lib/perfsonar/grafana/provisioning/datasources/
+apiVersion: 1
+
+deleteDatasources:
+  - name: Microdep jitter
+    orgId: 1
+
+datasources:
+  - name: Microdep jitter
+    type: grafana-opensearch-datasource
+    access: proxy
+    orgId: 1
+    uid: microdep-jitter
+    url: https://localhost/opensearch
+    basicAuth: false
+    isDefault: false
+    jsonData:
+      database: "dragonlab_jitter"
+      flavor: "opensearch"
+      version: "2.6.0"
+      timeField: "@timestamp"
+      maxConcurrentShardRequests: 5
+      pplEnabled: true
+      tlsAuth: false
+      tlsSkipVerify: true


### PR DESCRIPTION
Adds a **hybrid** Grafana integration: tabular / statistical / time-series views rendered **natively** in Grafana (querying the same OpenSearch archive directly), plus the geographic map embedded as an iframe. Purely additive — new files under `etc/grafana/` only (merge-base `c82358d`); it does not touch the map frontend. Complements the existing `grafana_dashboard_patch` button.

### Dashboards (folder "Microdep")
- **Gaps overview** — total gaps (stat), gaps over time, top-10 source hosts, link to the map.
- **Map** — the full `/microdep/` map embedded as a themable full-size `<iframe>` (needs `[panels] disable_sanitize_html = true`, which perfSONAR sets; the map is same-origin so it frames fine).
- **Details** — jitter percentiles over time (`h_jit` p50/p95/p99), top link pairs by time-lost (`tloss`), a source×target gap matrix via the **`esnet-matrix-panel`** plugin, and gap/jitter data-freshness stats.

### Datasources
Two `grafana-opensearch-datasource` provisioning files, mirroring perfSONAR's own `perfsonar-local.yaml`: `microdep-dragonlab` (index `dragonlab`) and `microdep-jitter` (index `dragonlab_jitter`). Time field is `@timestamp` (the only date-typed field; `timestamp` is epoch-float, `datetime` is text). Term aggs use `.keyword`.

### Notes
- Requires the `grafana-opensearch-datasource` and `esnet-matrix-panel` plugins — both already present on the perfSONAR Grafana.
- `etc/grafana/README.md` documents provisioning + gotchas.
- Every query verified live through Grafana's datasource proxy on a test host; all dashboards provision cleanly.
- Not yet wired into the deb/rpm packaging (provisioned manually per the README) — left for a follow-up once the approach is agreed.