### PR TITLE
Keep the map visible for topology-only periods; move "no data" into the popup (#113)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -1591,6 +1591,18 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sor
 .link-host:hover { color: var(--c-accent); }
 .link-host.copied { color: var(--c-accent); }
 
+/* Shown in the link popup when a (grey topology) link has no event data for the
+   selected period — issue #113. */
+.link-panel-nodata {
+    margin: 10px 2px 0;
+    padding: 10px 12px;
+    color: var(--c-text-2);
+    font-size: .85rem;
+    background: var(--c-elevated);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r);
+}
+
 /* Transient "copied to clipboard" toast (bottom-centre, theme-aware). */
 .copy-toast {
     position: fixed;

--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -3222,20 +3222,32 @@ table#legend.compare-legend th button {
 .tabnav-tool-btn:hover { background: var(--c-control-h); color: var(--c-text); }
 
 /* Empty-state overlay shown over the map when no links are present. */
+/* A compact notice card, not a full-map curtain: the map (topology, markers)
+   stays visible and usable around it — issue #113. */
 .map-empty-overlay {
     position: absolute;
-    inset: 0;
+    top: 16px;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 5;
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
     text-align: center;
-    padding: 24px;
-    background: color-mix(in srgb, var(--c-bg) 85%, transparent);
+    max-width: min(420px, calc(100% - 32px));
+    padding: 12px 18px;
+    background: color-mix(in srgb, var(--c-elevated) 94%, transparent);
+    border: 1px solid var(--c-border);
+    border-radius: var(--r);
+    box-shadow: 0 6px 24px rgba(0, 0, 0, .28);
     color: var(--c-text-2);
     pointer-events: none;
 }
+.map-empty-overlay h3 { font-size: .95rem; margin: 0 0 4px; }
+.map-empty-overlay p  { font-size: .82rem; margin: 0; }
+/* The hint list is useful but bulky — keep the card small. */
+.map-empty-overlay ul { display: none; }
+.map-empty-overlay .map-empty-icon svg { width: 22px; height: 22px; }
 .map-empty-overlay[hidden] { display: none; }
 .map-empty-overlay h3 {
     margin: 12px 0 4px;

--- a/microdep/perfsonar-microdep/microdep-map/index.html
+++ b/microdep/perfsonar-microdep/microdep-map/index.html
@@ -293,8 +293,8 @@
             <div class="map-empty-icon">
               <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
             </div>
-            <h3>No links for this period</h3>
-            <p id="map_empty_msg">No measurement data was returned for the selected time window.</p>
+            <h3>No event-data available for this period</h3>
+            <p id="map_empty_msg">Topology is shown where available. Try Prev, a wider Period, or another Event type.</p>
             <ul>
               <li>Click <strong>Prev</strong> to step back to a date with data.</li>
               <li>Switch to a wider <strong>Period</strong> (Day → Week → 4 weeks).</li>

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -3711,16 +3711,8 @@ function load_coords(network, service, goal){
 		}
 		if ( ! result.responses.length ) { console.log("No node data returned from archive for time period " + start_iso + " to " + end_iso + "."); }
 	    }
-	    loads++;
-	    if (loads >= goal) {
-		// All other calls to load_coords() have completed.
-		loads=0;
-		show_map(network);
-		if (points.length > 0)
-		    // Some nodes are available. Plot the links too.
-		    get_topology();
-	    }
-	}).fail( function(e, textStatus, error ) { console.log( "Request" + url + " Failed: " + textStatus + ", " + error ); loads++; });
+	    _coords_load_done(network, goal);
+	}).fail( function(e, textStatus, error ) { console.log( "Request" + url + " Failed: " + textStatus + ", " + error ); _coords_load_done(network, goal); });
 	return;
     }
     if ( service === "db" ) {
@@ -3735,9 +3727,8 @@ function load_coords(network, service, goal){
 		let point_already_loaded = points.find(o => o.id === p.id);
 		if (! point_already_loaded) { points.push( p); } else { console.log( "Duplicate node info for node " + p.id ); }
 	    }
-	    loads++;
-	    if (loads >= goal) { loads=0; show_map(network); if (points.length > 0) get_topology(); else _set_map_empty_state(true); }
-	}).fail( function( jqxhr, textStatus, error ) { console.log( "Request" + url + " Failed: " + textStatus + ", " + error ); loads++; });
+	    _coords_load_done(network, goal);
+	}).fail( function( jqxhr, textStatus, error ) { console.log( "Request" + url + " Failed: " + textStatus + ", " + error ); _coords_load_done(network, goal); });
 	return;
     }
     var url= "./" + network + "/" + network + "-" + service + "-geo.json";
@@ -3756,9 +3747,23 @@ function load_coords(network, service, goal){
 		if (! point_already_loaded) { points.push( tjenester[t]); } else { console.log( "Duplicate node info for node " + t.id ); }
 	    }
 	}
-	loads++;
-	if (loads >= goal) { loads=0; show_map(network); if (points.length > 0) get_topology(); else _set_map_empty_state(true); }
-    }).fail( function( jqxhr, textStatus, error ) { console.log( "Request" + url + " Failed: " + textStatus + ", " + error ); loads++; });
+	_coords_load_done(network, goal);
+    }).fail( function( jqxhr, textStatus, error ) { console.log( "Request" + url + " Failed: " + textStatus + ", " + error ); _coords_load_done(network, goal); });
+}
+
+// Called when ONE load_coords() source finishes — success or failure. Once all
+// sources are done, show the map and either plot the topology or, when no nodes
+// were found at all, show the empty-period notice. Every completion path must go
+// through here: previously the "topoevents" branch had no else and the .fail()
+// handlers never re-checked the counter, so a date with no nodes (or a failed
+// request) left a silently blank map with no explanation (issue #113).
+function _coords_load_done(network, goal) {
+    loads++;
+    if (loads < goal) return;
+    loads = 0;
+    show_map(network);
+    if (points.length > 0) get_topology();
+    else _set_map_empty_state(true);
 }
 
 function load_coords_from_all_sources(network){

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -1652,6 +1652,11 @@ function make_tooltip_v2(fromHost, toHost, link){
 	    }
 	}
 	tip+="</table>";
+	if (nrows === 0) {
+	    // Topology-only link (grey): no event data for this period. Surface it
+	    // here in the popup instead of a map-covering overlay (issue #113).
+	    tip += '<p class="link-panel-nodata">No event-data available for this period.</p>';
+	}
 	return tip;
     } else {
 	console.log('Error: No config loaded. Not able to prepare tooltips.');
@@ -2378,15 +2383,33 @@ function _is_map_visually_empty() {
     }
     return !anyColoured;   // true when no layer OR every layer is grey
 }
+// Whether the map currently has ANY link layer (coloured OR grey topology).
+function _has_any_links() {
+    if (typeof mymap === 'undefined' || !mymap) return false;
+    if (typeof realLocationsMode !== 'undefined' && realLocationsMode) {
+        return !!(typeof realPathLines !== 'undefined' && realPathLines
+                  && Object.keys(realPathLines).length > 0);
+    }
+    for (var k in linkByName) {
+        var l = linkByName[k];
+        if (!l || typeof l !== 'object') continue;
+        if (mymap.hasLayer && !mymap.hasLayer(l)) continue;
+        return true;
+    }
+    return false;
+}
 function _set_map_empty_state(empty) {
-    var el = document.getElementById('map_empty_overlay');
-    if (!el) return;
-    el.hidden = !empty;
-    // Hide the threshold legend together with the overlay — it describes a
-    // property scale that doesn't apply when nothing is measured. The
-    // tabsactivate handler restores display:'' when data returns.
+    // Hide the threshold legend when there's no coloured event data — it
+    // describes a scale that doesn't apply. (tabsactivate restores it.)
     var lg = document.getElementById('legend');
     if (lg) lg.style.display = empty ? 'none' : '';
+    // Only cover the map with the overlay when there's literally nothing to show
+    // (no links at all). When topology links are present (grey, no event data)
+    // keep the map visible + clickable — the "no event data" note lives in the
+    // link popup instead (issue #113).
+    var el = document.getElementById('map_empty_overlay');
+    if (!el) return;
+    el.hidden = !(empty && !_has_any_links());
 }
 
 // --- Clear-all-tabs (#16) ------------------------------------------------

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -3736,7 +3736,7 @@ function load_coords(network, service, goal){
 		if (! point_already_loaded) { points.push( p); } else { console.log( "Duplicate node info for node " + p.id ); }
 	    }
 	    loads++;
-	    if (loads >= goal) { loads=0; show_map(network); if (points.length > 0) get_topology(); }
+	    if (loads >= goal) { loads=0; show_map(network); if (points.length > 0) get_topology(); else _set_map_empty_state(true); }
 	}).fail( function( jqxhr, textStatus, error ) { console.log( "Request" + url + " Failed: " + textStatus + ", " + error ); loads++; });
 	return;
     }
@@ -3757,7 +3757,7 @@ function load_coords(network, service, goal){
 	    }
 	}
 	loads++;
-	if (loads >= goal) { loads=0; show_map(network); if (points.length > 0) get_topology(); }
+	if (loads >= goal) { loads=0; show_map(network); if (points.length > 0) get_topology(); else _set_map_empty_state(true); }
     }).fail( function( jqxhr, textStatus, error ) { console.log( "Request" + url + " Failed: " + textStatus + ", " + error ); loads++; });
 }
 


### PR DESCRIPTION
Resolves #113 (reported by @ottojwittner).

### Before
When a period has only topology data (grey links, no event data), a semi-transparent full-map overlay saying **"No links for this period"** covered the map — even though the topology is present and clickable. And on a period with no data at all, the same curtain hid the map entirely.

### After
- **The notice is a compact card** pinned to the top of the map instead of a full-map curtain, so the map, topology and markers stay visible and usable around it (`pointer-events: none`, so clicks pass through).
- **Reworded** to *"No event-data available for this period"* — links from topology events may well be present.
- **Clicking a grey (no-data) link** shows *"No event-data available for this period."* inside the **link popup** (`make_tooltip_v2`, when the property table comes out empty) — the requested "move it into the popup" behaviour.
- **The curtain-style overlay no longer applies when topology links exist** (`_set_map_empty_state` + new `_has_any_links` helper); the threshold legend still hides when there is no coloured event data.

### Also fixed while testing (same area)
The notice appeared when **stepping back** from a date with data, but a **direct visit or reload** of that same date gave a silently blank map with no explanation. Cause: `load_coords()` only called `get_topology()` when points were found, so on an empty date the empty-state was never evaluated. Both call sites now set it when no points come back, so navigation and reload behave identically.

### Testing
JS syntax-checked; deployed to a test host and exercised (topology-only period, empty period, reload vs. step-back). Worth a final visual check by the reporter.

Closes #113