### PR TITLE
Show config help texts in the link-popup summary table (#108)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -1638,7 +1638,10 @@ function make_tooltip_v2(fromHost, toHost, link){
 	    for (const sum_var in conffile[parms.net].event_type[parms.event].field) {
 		if ( typeof link[sum_var] != 'undefined' ) {
 		    var prop_value = Math.round((link[sum_var] + Number.EPSILON) * 100) / 100;
-		    tip+= '<tr><td>' + prop_desc[parms.event][sum_var] + '<td align=right>' + prop_value;
+		    // Config `descr` as a mouse-over help text on the row (issue #108).
+		    var help1 = (prop_long_desc[parms.event] && prop_long_desc[parms.event][sum_var])
+			? ' title="' + escapeHtml(prop_long_desc[parms.event][sum_var]) + '"' : '';
+		    tip+= '<tr' + help1 + '><td>' + prop_desc[parms.event][sum_var] + '<td align=right>' + prop_value;
 		    nrows++;
 		}
 	    }
@@ -1646,7 +1649,11 @@ function make_tooltip_v2(fromHost, toHost, link){
 	    for (const sum_var of conffile[parms.net].event_type[parms.event].popup.summary) {
 		if ( typeof link[sum_var] != 'undefined' ) {
 		    var prop_value = Math.round((link[sum_var] + Number.EPSILON) * 100) / 100;
-		    tip+= '<tr><td>' + prop_desc[conffile[parms.net].event_type[parms.event].summary_event_type][sum_var] + '<td align=right>' + prop_value;
+		    // Config `descr` as a mouse-over help text on the row (issue #108).
+		    var sum_key = conffile[parms.net].event_type[parms.event].summary_event_type;
+		    var help2 = (prop_long_desc[sum_key] && prop_long_desc[sum_key][sum_var])
+			? ' title="' + escapeHtml(prop_long_desc[sum_key][sum_var]) + '"' : '';
+		    tip+= '<tr' + help2 + '><td>' + prop_desc[sum_key][sum_var] + '<td align=right>' + prop_value;
 		    nrows++;
 		}
 	    }


### PR DESCRIPTION
Follow-up on the reopened #108.

#109 restored the mouse-over help texts on the network / event-type / property **dropdowns**, but as @ottojwittner points out they should also appear on the **properties/values in the summary table of the link-detail popup**.

Each property row built by `make_tooltip_v2` now carries the field's config `descr` as a `title`, taken from `prop_long_desc` — the same structure the dropdowns use, so the text is identical and there is no second source to maintain. Applied to both branches (the live/today field list and the summary-event field list); a row with no description in the config simply gets no title. The value is escaped (`escapeHtml`).

### Testing
JS syntax-checked; deployed to a test host. Hovering a row in the link popup shows the field description from `mapconfig.yml` (summary fields inherit the standard field's `descr`, which map-lib already does).