### PR TITLE
Give a newly opened tab focus (#117)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/js/map-lib.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/map-lib.js
@@ -247,10 +247,13 @@ export function add_tab(type, title, num_tabs, html){
     // some count non-tab <li> children), so `active: num_tabs-1` often selected
     // the previous tab and the new one stayed hidden behind the map (issue #117).
     // Look up the <li> that controls this panel instead.
-    var $tab_items = $("main#tabs > ul > li");
-    var new_idx = $tab_items.index($tab_items.filter(function(){
-	return $(this).attr("aria-controls") === divid;
-    }));
+    // NOTE: the tab-nav <ul> also holds non-tab <li> items (the sidebar-open and
+    // clear-all-tabs buttons, and the "+" report select). jQuery UI only counts
+    // <li> that contain an <a href> as tabs, so any index derived from the raw
+    // <li> count is too high and selecting it silently leaves the map active.
+    // Index within the anchor set instead, matching jQuery UI's own numbering.
+    var $tab_links = $("main#tabs > ul > li > a");
+    var new_idx = $tab_links.index($tab_links.filter("[href='#" + divid + "']"));
     if (new_idx >= 0) $("main#tabs").tabs("option", "active", new_idx);
 
     // activate sorting if sortable tables within

--- a/microdep/perfsonar-microdep/microdep-map/js/map-lib.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/map-lib.js
@@ -242,7 +242,16 @@ export function add_tab(type, title, num_tabs, html){
     );
     $("#"+divid).html(html);
     $("main#tabs").tabs("refresh");
-    $('main#tabs').tabs({ active: num_tabs-1});
+    // Focus the tab we just created. Activating by index was fragile: callers
+    // compute num_tabs in different ways (most count the tabs BEFORE adding, and
+    // some count non-tab <li> children), so `active: num_tabs-1` often selected
+    // the previous tab and the new one stayed hidden behind the map (issue #117).
+    // Look up the <li> that controls this panel instead.
+    var $tab_items = $("main#tabs > ul > li");
+    var new_idx = $tab_items.index($tab_items.filter(function(){
+	return $(this).attr("aria-controls") === divid;
+    }));
+    if (new_idx >= 0) $("main#tabs").tabs("option", "active", new_idx);
 
     // activate sorting if sortable tables within
     let collection= document.getElementById(divid).getElementsByClassName("sortable");

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -4218,7 +4218,10 @@ function init_map(){
 	if (report_type !== 'choose') {
 	    persistTab(tab_id, { kind: 'check', report_type: report_type, title: title });
 	}
-	$("#check").val('choose'); $("#tabs").tabs("option", "active", num_tabs);
+	// add_tab() focuses the new tab itself; the old activate-by-num_tabs here
+	// counted the non-tab <li> items too and selected a non-existent index,
+	// which left the map active (issue #117).
+	$("#check").val('choose');
     });
     // (Right-click coordinate alert intentionally removed — it was a leftover
     // debug helper. Do not re-add: it pops an alert(lat,lng) on every


### PR DESCRIPTION
Resolves #117 (reported by @ottojwittner).

### Cause
`add_tab()` activated the new tab **by index**: `$('main#tabs').tabs({ active: num_tabs-1 })`. But callers compute `num_tabs` in different ways — most count the tabs **before** adding the new one, so `num_tabs-1` is the *previous* last tab (usually the map), and some count non-tab `<li>` children too. The tab was created but the map stayed active, so the new tab looked hidden until clicked. Two call sites already carried an explicit workaround (re-activating the last tab right after `add_tab`).

### Fix
Activate **by panel id**: after `tabs("refresh")`, find the `<li>` whose `aria-controls` matches the panel just created and set that index active. Index arithmetic in the callers no longer matters, and it fixes every caller at once (reports, curve, routes, LS, heatmap-cell curves).

### Testing
JS syntax-checked and deployed to a test host. The approach relies on `aria-controls`, which jQuery UI sets on refresh and which this file already uses elsewhere (the close-tab handler and `clear_all_tabs`). I could not reach the test host from a browser here, so a quick click-test ("+" → Summary should open focused) would be worth doing before merge.

Closes #117