### PR TITLE
Traceroute peer list: keep the full archive base on peer buttons (#118)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/js/ls-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/ls-tab.js
@@ -361,7 +361,10 @@ export function ls_tab(div_id, from, to, time_start, time_end, options = {}) {
         const start_iso = new Date(t_start * 1000).toISOString();
         const end_iso   = new Date(t_end   * 1000).toISOString();
 
-        const server = mahost.split('/').slice(0, 3).join('/');
+        // NB: keep the FULL archive base (mahost) everywhere below, including on
+        // the peer buttons. get-tracetests.pl needs the complete base URL; given
+        // only the origin it answers "Resource not found." (plain text), which
+        // then fails to parse as JSON (issue #118).
 //        const fetch_url = '/pstracetree/get-tracetests.pl?' + verify_SSL_qs('') +
         const fetch_url = 'get-tracetests.pl?' + verify_SSL_qs('') +
                           (params.verify_SSL !== undefined ? '&' : '') +
@@ -400,7 +403,7 @@ export function ls_tab(div_id, from, to, time_start, time_end, options = {}) {
                 const tu = new Date(buckets[r].timestamp.value);
                 body += '<tr>' +
                           '<td>' + tu.toLocaleDateString() + 'T' + tu.toLocaleTimeString() + '</td>' +
-                          '<td><button class="knapp ls-pair-btn" data-action="os-pair" data-server="' + server + '"' +
+                          '<td><button class="knapp ls-pair-btn" data-action="os-pair" data-server="' + mahost + '"' +
                             ' data-from="' + peer_from + '" data-to="' + peer_to + '"' +
                             ' data-start="' + t_start + '" data-end="' + t_end + '">' + pair_key + '</button></td>' +
                         '</tr>';


### PR DESCRIPTION
Resolves #118 (reported by @ottojwittner).

### Cause
In the Routes tab, the Peers list is fetched with the **full archive base** (`mahost`, e.g. `https://host/opensearch`), but each peer button was given `mahost.split('/').slice(0,3).join('/')` — the **origin only**, with the path stripped. Clicking a peer therefore requested `get-tracetests.pl?mahost=https://host`, which answers `Resource not found.` as plain text, and jQuery's `$.getJSON` failed to parse it — the reported JSON error. It failed even for the pair the view was opened with, because the initial auto-open takes a different path that passes the untruncated `mahost`.

Verified on a test host:

```
mahost=https://localhost/opensearch  -> {"took":998,... "aggregations":{"peers":...   # valid JSON
mahost=https://localhost             -> Resource not found.                            # not JSON
```

### Fix
Put the full `mahost` on the peer buttons and drop the truncated-origin helper in the OpenSearch path. The esmond path keeps its own `server` variable, which it legitimately needs to build `server + base-uri`.

### Note for a separate issue
While in this file: the esmond/lookup-service path still calls a hard-coded `/pstracetree/cors.pl` (three places). That CGI is not shipped by microdep — it only answers on hosts that still have a legacy pstracetree install, so on a clean host those lookups would 404 in the same "not JSON" way. Left untouched here since fixing it properly means shipping (and restricting) a proxy CGI; happy to open a separate issue if you agree.

Closes #118