### PR TITLE
Ship the OpenSearch grant guard disabled by default (#112)

### DIFF
--- a/microdep/perfsonar-microdep/unibuild-packaging/deb/rules
+++ b/microdep/perfsonar-microdep/unibuild-packaging/deb/rules
@@ -20,3 +20,7 @@ override_dh_installsystemd:
 	dh_installsystemd --name=perfsonar-microdep-gap-ana
 	dh_installsystemd --name=perfsonar-microdep-trace-ana
 	dh_installsystemd --name=perfsonar-microdep-restart
+# The OpenSearch read-grant guard is a stop-gap: install the units, but leave
+# them disabled so an admin opts in with
+#   systemctl enable --now perfsonar-microdep-opensearch-guard.timer
+	dh_installsystemd --name=perfsonar-microdep-opensearch-guard --no-enable --no-start

--- a/microdep/perfsonar-microdep/unibuild-packaging/rpm/perfsonar-microdep.spec
+++ b/microdep/perfsonar-microdep/unibuild-packaging/rpm/perfsonar-microdep.spec
@@ -355,11 +355,11 @@ systemctl start perfsonar-microdep-hourly-aggregator.timer || true
 # Add Microdep to Opensearch setup (including Logstash)
 /usr/lib/perfsonar/bin/microdep_commands/opensearch_config_microdep.sh || true
 
-# Self-heal timer: re-apply the OpenSearch read grant if a perfSONAR/OpenSearch
-# upgrade later resets roles.yml and drops it.
+# Self-heal timer: re-applies the OpenSearch read grant if a perfSONAR/OpenSearch
+# upgrade later resets roles.yml and drops it. Installed but NOT enabled - it is
+# a stop-gap, so an admin opts in explicitly with
+#   systemctl enable --now perfsonar-microdep-opensearch-guard.timer
 systemctl daemon-reload || true
-systemctl enable perfsonar-microdep-opensearch-guard.timer || true
-systemctl start perfsonar-microdep-opensearch-guard.timer || true
 
 if [ ! -f /etc/perfsonar/microdep/microdep-ana-archive.json ]; then
     # Prepare default logstash archive config for analytic results


### PR DESCRIPTION
Addresses the remaining half of #112.

#110 added the self-heal timer for the OpenSearch read grant and enabled it on install. @ottojwittner asked that this stop-gap ship **disabled by default**, so this PR does that — the units are still packaged, and an admin opts in with:

```
systemctl enable --now perfsonar-microdep-opensearch-guard.timer
```

- **rpm**: dropped the `enable`/`start` from `%post logstash`. `%preun` still stops/disables it, so removal stays clean if an admin turned it on.
- **deb**: the guard units were in fact **not installed at all** — `debian/rules` overrides `dh_installsystemd` and only named the three older units, so the ones added in #110 were skipped. Added with `--no-enable --no-start`: installed, but left off.

The other half of #112 — re-running `opensearch_config_microdep.sh` on package upgrades — already happens today: rpm `%post logstash` and the deb postinst both call it on install and upgrade.

### Note
Packaging-only change; I can't build the deb/rpm here, so a build check by whoever produces the packages would be worthwhile (in particular that the guard units now land in the deb and are left disabled).