### PR TITLE
Add a "Routes" entry to the tab menu (#124)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/index.html
+++ b/microdep/perfsonar-microdep/microdep-map/index.html
@@ -268,6 +268,7 @@
               <option value="missing" title="Missing opposite links">Missing</option>
               <option value="asymmetry" title="Asymmetry in selected variable">Asymmetry</option>
               <option value="summary" title="Table of alle variables">Summary</option>
+              <option value="routes" title="Traceroute peers for the selected period">Routes</option>
             </select>
             <div class="custom-select compact" data-target="check"></div>
           </li>

--- a/microdep/perfsonar-microdep/microdep-map/js/ls-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/ls-tab.js
@@ -542,7 +542,10 @@ export function ls_tab(div_id, from, to, time_start, time_end, options = {}) {
         const inner_id = id + '-trace-inner';
         const trace_pane = el('trace');
         trace_pane.innerHTML = '<div id="' + inner_id + '"></div>';
-        $('#' + id + '-tabs').tabs({ active: 2 });
+        // Sub-tabs are Traceroute (0) and Peers (1) - the old `active: 2` is a
+        // leftover from a three-tab layout and selects nothing, so opening a
+        // pair from the Peers list never switched to the graph.
+        $('#' + id + '-tabs').tabs({ active: 0 });
 
         tracetree_tab(inner_id, p_from, p_to, t_start, t_end, {
             mahost:     mahost,
@@ -619,11 +622,19 @@ export function ls_tab(div_id, from, to, time_start, time_end, options = {}) {
         // archive recorded — exact-string match on from/to is required by the
         // backend or the hop graph comes back empty).
         if (params.from && params.to) {
-            $('#' + id + '-tabs').tabs({ active: 2 });
+            $('#' + id + '-tabs').tabs({ active: 0 });
             el('trace').innerHTML =
                 '<div class="center-text" style="padding:40px">' +
                   '<div class="spinner"></div>' +
                   '<p>Resolving peer pair for ' + params.from + ' → ' + params.to + '…</p>' +
+                '</div>';
+        } else {
+            // Opened without a pair (the map's "Routes" menu entry): show the
+            // Peers list, which is what the user came for (issue #124).
+            $('#' + id + '-tabs').tabs({ active: 1 });
+            el('peers').innerHTML =
+                '<div class="center-text" style="padding:40px">' +
+                  '<div class="spinner"></div><p>Loading traceroute peers…</p>' +
                 '</div>';
         }
 

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -4212,6 +4212,26 @@ function init_map(){
 	case 'missing': add_tab( 'div', title, num_tabs, check_asymmetry(report_type, tab_id) ); break;
 	case 'asymmetry': add_tab( 'div', title, num_tabs, check_asymmetry(report_type, tab_id) ); break;
 	case 'summary': add_tab( 'div', title, num_tabs, report_summary(tab_id) ); break;
+	case 'routes': {
+	    // Traceroute browser for the whole topology: launched without a peer
+	    // pair, so ls_tab opens on its Peers list for the selected period
+	    // (issue #124). Same archive/options as the link popup's Routes button.
+	    add_tab( 'div', title, num_tabs,
+		     '<div class="center-text" style="padding:40px"><div class="spinner"></div><p>Loading traceroute peers\u2026</p></div>' );
+	    var routes_start = new Date($("#datepicker").val()).getTime() / 1000;
+	    var routes_end   = routes_start + parms.period * 3600;
+	    var menuRoutesOpts = {
+		net: parms.net,
+		mahost: 'https://localhost:9200/',
+		verify_SSL: 0,
+		api: 'opensearch'
+	    };
+	    if (! jQuery.isEmptyObject(conffile[parms.net].archive) ) {
+		menuRoutesOpts.mahost = conffile[parms.net].archive;
+	    }
+	    ls_tab( tab_id, '', '', routes_start, routes_end, menuRoutesOpts );
+	    break;
+	}
 	case 'heatmap':
 	    let template_url='curve-chart.html?net=' + parms.net + '&index=' + event_index[parms.event] + '&from={0}&to={1}&event=' + parms.event + '&property=h_ddelay&start=' + start + '&end=' + end + "&title=\"From {2} to {3}\"";
 	    add_tab( 'div', title, num_tabs, 'This will be graph soon'); heatmap(tab_id, summary, $("#prop_select").val(), get_color, threshes, title_state(), template_url, open_heatmap_cell ); break;


### PR DESCRIPTION
Resolves #124 (requested by @ottojwittner).

Adds a **Routes** option to the "+" tab menu above the map. It opens the traceroute viewer for the currently selected period **without** a specific peer pair, so it lands on the **Peers** list of every flow in the archive; picking a pair there opens its topology as before. Archive URL and options are the same ones the link popup's Routes button uses, and the tab is restored across reloads by the existing `#check` persistence (no extra code).

`ls_tab` needed two adjustments:

- **Focus the Peers sub-tab** (with a loading spinner) when launched without a `from`/`to` pair — previously it stayed on the empty Traceroute pane, even though the peers fetch runs regardless.
- **Fix the sub-tab indices.** There are only two sub-tabs — Traceroute (0) and Peers (1) — but two places asked for `active: 2`, a leftover from an older three-tab layout. That index selects nothing, so opening a pair from the Peers list never switched to the graph.

### Testing
JS syntax-checked (modules + inline) and deployed to a test host. Worth a click-test: "+" → Routes should open focused on the Peers list for the selected date/period, and clicking a pair should switch to its Traceroute view.

Closes #124