### PR TITLE
Traceroute viewer: follow the selected network's IP version (#127)

### DIFF
--- a/microdep/perfsonar-microdep/bin/microdep_commands/get-tracetests.pl
+++ b/microdep/perfsonar-microdep/bin/microdep_commands/get-tracetests.pl
@@ -67,12 +67,22 @@ my $to = $cgi->param("to");
 my $verify_SSL= 1;
 $verify_SSL = $cgi->param("verify_SSL") if (defined $cgi->param("verify_SSL"));
 
+# Optional IP-version filter. The map passes the selected network's version so a
+# Net-6 traceroute view does not fall back to the v4 traces (issue #127). Only
+# 4 and 6 are accepted; anything else (including an empty value, meaning "all
+# versions") leaves the results unfiltered.
+my $ip_version = $cgi->param("ip_version");
+my $ipv_filter = '';
+if (defined $ip_version && $ip_version =~ /^([46])$/) {
+    $ipv_filter = ', { "term": { "test.spec.ip-version": ' . $1 . ' } }';
+}
+
 # Prepare query
 my $query='';
 if (! $from || ! $to ) {
     # Search for all peers with trace test results available
     $query = '{ "query": { "bool": { "filter": [ { "term": { "test.type.keyword": "trace" } }, 
-                                                 { "range": { "@timestamp": { "gte": "' . $iso_start . '", "lt": "' . $iso_end . '" } } } ] } },
+                                                 { "range": { "@timestamp": { "gte": "' . $iso_start . '", "lt": "' . $iso_end . '" } } }' . $ipv_filter . ' ] } },
 		"size": 0,
   	        "aggs": { "peers": { "multi_terms": { "terms": [ { "field": "test.spec.source.keyword"}, 
                                                                 { "field": "test.spec.dest.keyword"} ],
@@ -99,7 +109,7 @@ if (! $from || ! $to ) {
         my $fl = join(',', map { '"' . $_ . '"' } @from_list);
         my $tl = join(',', map { '"' . $_ . '"' } @to_list);
         $query = '{ "query": { "bool": { "filter": [ { "term": { "test.type.keyword": "trace" } },
-                       { "range": { "@timestamp": { "gte": "' . $iso_start . '", "lt": "' . $iso_end . '" } } },
+                       { "range": { "@timestamp": { "gte": "' . $iso_start . '", "lt": "' . $iso_end . '" } } }' . $ipv_filter . ',
                        { "bool": { "minimum_should_match": 1, "should": [
                            { "bool": { "must": [ { "terms": { "test.spec.source.keyword": [' . $fl . '] } }, { "terms": { "test.spec.dest.keyword": [' . $tl . '] } } ] } },
                            { "bool": { "must": [ { "terms": { "test.spec.source.keyword": [' . $tl . '] } }, { "terms": { "test.spec.dest.keyword": [' . $fl . '] } } ] } }
@@ -109,7 +119,7 @@ if (! $from || ! $to ) {
         $query = '{ "query": { "bool": { "filter": [ { "term": { "test.type.keyword": "trace" } },
                                                      { "term": { "test.spec.source.keyword": "' . $from . '" } },
                                                      { "term": { "test.spec.dest.keyword": "' . $to . '" } },
-                                                     { "range": { "@timestamp": { "gte": "' . $iso_start . '", "lt": "' . $iso_end . '" } } }
+                                                     { "range": { "@timestamp": { "gte": "' . $iso_start . '", "lt": "' . $iso_end . '" } } }' . $ipv_filter . '
                                                    ] } }, "size": 8640 }';
     }
 }

--- a/microdep/perfsonar-microdep/microdep-map/js/ls-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/ls-tab.js
@@ -52,7 +52,9 @@ export function ls_tab(div_id, from, to, time_start, time_end, options = {}) {
         verify_SSL:  options.verify_SSL,
         api:         options.api        || '',
         stime:       options.stime,
-        ip_version:  options.ip_version || 4
+        // Empty/absent means "all versions" (the config allows that) - only
+        // filter when the network actually pins one (issue #127).
+        ip_version:  options.ip_version
     };
 
     // Compute time range (epoch seconds)
@@ -370,7 +372,8 @@ export function ls_tab(div_id, from, to, time_start, time_end, options = {}) {
                           (params.verify_SSL !== undefined ? '&' : '') +
                           'mahost=' + encodeURIComponent(mahost) +
                           '&start=' + encodeURIComponent(start_iso) +
-                          '&end='   + encodeURIComponent(end_iso);
+                          '&end='   + encodeURIComponent(end_iso) +
+                          (params.ip_version ? '&ip_version=' + encodeURIComponent(params.ip_version) : '');
 
         const start = new Date(t_start * 1000);
         const end   = new Date(t_end   * 1000);
@@ -550,7 +553,8 @@ export function ls_tab(div_id, from, to, time_start, time_end, options = {}) {
         tracetree_tab(inner_id, p_from, p_to, t_start, t_end, {
             mahost:     mahost,
             verify_SSL: params.verify_SSL,
-            api:        api
+            api:        api,
+            ip_version: params.ip_version
         });
     }
 

--- a/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/microdep-map.js
@@ -1353,7 +1353,10 @@ function link_popup(link){
 		net: parms.net,
 		mahost: 'https://localhost:9200/',
 		verify_SSL: 0,
-		api: 'opensearch'
+		api: 'opensearch',
+		// Follow the selected network's IP version, so Net-6 shows v6
+		// traceroutes instead of always falling back to v4 (issue #127).
+		ip_version: net_ip_version[parms.net]
 	    };
 	    if(! jQuery.isEmptyObject(conffile[parms.net].archive) ) {
 		routesOpts.mahost = conffile[parms.net].archive;
@@ -4224,7 +4227,8 @@ function init_map(){
 		net: parms.net,
 		mahost: 'https://localhost:9200/',
 		verify_SSL: 0,
-		api: 'opensearch'
+		api: 'opensearch',
+		ip_version: net_ip_version[parms.net]
 	    };
 	    if (! jQuery.isEmptyObject(conffile[parms.net].archive) ) {
 		menuRoutesOpts.mahost = conffile[parms.net].archive;

--- a/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
@@ -64,7 +64,7 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
         mahost:     options.mahost  || '',
         verify_SSL: options.verify_SSL,
         api:        options.api     || '',
-        'ip-version': options.ip_version || 4,
+        'ip-version': options.ip_version,     // unset = all versions (issue #127)
         start:      time_start,
         end:        time_end
     };
@@ -570,6 +570,9 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
 	
         if (params.verify_SSL !== undefined) {
             url += '&verify_SSL=' + params.verify_SSL;
+        }
+        if (params['ip-version']) {
+            url += '&ip_version=' + encodeURIComponent(params['ip-version']);
         }
 
         console.log('Fetching traceroutes via: ' + url);


### PR DESCRIPTION
Resolves #127 (reported by @ottojwittner). Your hunch was right — a missing `ip_version`, in four places.

### Cause
The plumbing was half there: `ls_tab` kept an `ip_version` in its params bag and `tracetree_tab` an `'ip-version'`, **both defaulting to 4** — but nothing ever passed the selected network's version in, neither the peers query nor the traceroute query sent it to the CGI, and `get-tracetests.pl` did not read such a parameter at all. So every view fell back to v4.

### Fix
- **`get-tracetests.pl`** — accepts `&ip_version=`; when it is `4` or `6` it adds a `{ "term": { "test.spec.ip-version": N } }` filter to all three query shapes (peers aggregation, candidate-list match, exact pair). Anything else — empty included, which is how `mapconfig.yml` expresses "all versions" — stays unfiltered.
- **`microdep-map.js`** — passes `net_ip_version[parms.net]` into both Routes launchers (the link-popup button and the tab-menu entry).
- **`ls-tab.js`** — sends `ip_version` with the peers query and hands it to `tracetree_tab`.
- **`tracetree-tab.js`** — appends it to the `get-tracetests.pl` URL.

The hardcoded `|| 4` defaults are dropped, so an unset version means "all versions" instead of silently forcing v4.

### Testing
`perl -c` clean on the host, JS syntax-checked, deployed to a test host and exercised through apache:

```
ip_version=(none) -> 7 peer pairs / 2016 hits
ip_version=4      -> 7 peer pairs / 2016 hits
ip_version=6      -> 0 peer pairs / 0 hits      # filter applies
```

Our test host only has v4 traces (`test.spec.ip-version` is 4 on all 130k trace records), so the filter is proven to *apply* but a positive v6 result needs a host that actually measures over v6 — worth a check on yours with Net-6 selected.

Closes #127