### PR TITLE
Traceroute viewer: report progress while parsing large trace sets (#130)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -1591,15 +1591,48 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sor
 .link-host:hover { color: var(--c-accent); }
 .link-host.copied { color: var(--c-accent); }
 
-/* Progress readout next to the traceroute spinner: parsing/laying out a large
-   trace set takes a while, so it counts up instead of looking frozen (#130). */
+/* Busy overlay for the traceroute topology: parsing/laying out a large trace set
+   takes a while, so it says how far along it is instead of looking frozen (#130).
+   Centred over the graph, big enough to read across the tab. */
+.tracetree-busy {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    background: color-mix(in srgb, var(--c-surface) 78%, transparent);
+    border-radius: var(--r);
+}
+.spinner-lg {
+    width: 56px;
+    height: 56px;
+    border-width: 5px;
+}
 .tracetree-progress {
-    display: block;
-    margin-top: 8px;
-    color: var(--c-text-2);
-    font-size: .82rem;
+    color: var(--c-text);
+    font-size: 1rem;
+    font-weight: 500;
     font-variant-numeric: tabular-nums;
     text-align: center;
+}
+.tracetree-progressbar {
+    width: min(320px, 60%);
+    height: 8px;
+    background: var(--c-control);
+    border: 1px solid var(--c-border);
+    border-radius: 999px;
+    overflow: hidden;
+}
+.tracetree-progressbar > span {
+    display: block;
+    width: 0;
+    height: 100%;
+    background: var(--c-accent);
+    border-radius: 999px;
+    transition: width .15s linear;
 }
 
 /* Shown in the link popup when a (grey topology) link has no event data for the

--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -1591,6 +1591,17 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sor
 .link-host:hover { color: var(--c-accent); }
 .link-host.copied { color: var(--c-accent); }
 
+/* Progress readout next to the traceroute spinner: parsing/laying out a large
+   trace set takes a while, so it counts up instead of looking frozen (#130). */
+.tracetree-progress {
+    display: block;
+    margin-top: 8px;
+    color: var(--c-text-2);
+    font-size: .82rem;
+    font-variant-numeric: tabular-nums;
+    text-align: center;
+}
+
 /* Shown in the link popup when a (grey topology) link has no event data for the
    selected period — issue #113. */
 .link-panel-nodata {

--- a/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
@@ -188,12 +188,16 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
     }
     function show_awaiting(on) {
         const a = el('awaiting');
-        if (a) a.style.display = on ? 'block' : 'none';
+        if (a) a.style.display = on ? 'flex' : 'none';
     }
     function set_progress(pct, label) {
         const p = el('progress');
-        if (!p) return;
-        p.textContent = (label || '') + (pct === null || pct === undefined ? '' : ' ' + pct + '%');
+        if (p) p.textContent = (label || '') + (pct === null || pct === undefined ? '' : ' ' + pct + '%');
+        const fill = el('progressfill');
+        if (fill) {
+            // No percentage yet (or done): show an empty bar rather than a stale one.
+            fill.style.width = (pct === null || pct === undefined ? 0 : Math.max(0, Math.min(100, pct))) + '%';
+        }
     }
 
     // ====================================================================
@@ -590,7 +594,7 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
     // ====================================================================
 
     function fetch_and_plot_json(slice, base) {
-        el('awaiting').style.display = 'block';
+        show_awaiting(true);
         show_time_info(slice);
         in_slice = slice;
 
@@ -625,7 +629,7 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
             let msg = "Failed to get traceroute data: " + textStatus + ", " + error;
             console.log(msg);
             show_popup(msg);
-            el('awaiting').style.display = 'none';
+            show_awaiting(false);
         });
     }
 
@@ -1548,7 +1552,7 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
         timeline.setCustomTime(start, 'start');
         timeline.setCustomTime(end, 'end');
         timeline.setWindow(start - range, end + range);
-        el('awaiting').style.display = 'none';
+        show_awaiting(false);
     }
 
     function zoom_by_factor(parms, factor) {
@@ -1562,7 +1566,7 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
     }
 
     function zoom_by_timeline_slice(start, range) {
-        el('awaiting').style.display = 'block';
+        show_awaiting(true);
 
         let n_slice = { start: start, range: range, end: start + range };
 
@@ -1636,7 +1640,11 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
     </ul>
     <div id="${id}-topo" class="tracetree-topo">
       <div class="tracetree-graph" id="${id}-treetainer">
-        <div class="center-text"><div class="spinner"></div><p>Processing topology...</p></div>
+        <div class="tracetree-busy" id="${id}-awaiting">
+          <div class="spinner spinner-lg"></div>
+          <div class="tracetree-progress" id="${id}-progress">Processing topology…</div>
+          <div class="tracetree-progressbar"><span id="${id}-progressfill"></span></div>
+        </div>
       </div>
       <div class="tracetree-sidebar">
         <div class="topo-controls">
@@ -1647,7 +1655,6 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
           <button class="knapp topo-btn" id="${id}-start">Start layout</button>
         </div>
         <div id="${id}-legend"></div>
-        <span id="${id}-awaiting" style="display:none"><div class="spinner"></div><span id="${id}-progress" class="tracetree-progress"></span></span>
       </div>
     </div>
     <div id="${id}-stats"></div>

--- a/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
@@ -177,6 +177,25 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
         return document.getElementById(id + '-' + suffix);
     }
 
+    // --- Cooperative chunking + progress readout -----------------------
+    // Parsing and laying out a large trace set (>5k traceroutes) keeps the
+    // main thread busy for minutes, so the page stops repainting and looks
+    // frozen. The heavy loops below process CHUNK items, then yield to the
+    // browser and report how far along they are (issue #130).
+    const CHUNK = 250;
+    function _yield() {
+        return new Promise(function (resolve) { setTimeout(resolve, 0); });
+    }
+    function show_awaiting(on) {
+        const a = el('awaiting');
+        if (a) a.style.display = on ? 'block' : 'none';
+    }
+    function set_progress(pct, label) {
+        const p = el('progress');
+        if (!p) return;
+        p.textContent = (label || '') + (pct === null || pct === undefined ? '' : ' ' + pct + '%');
+    }
+
     // ====================================================================
     //  Colour limits / legend
     // ====================================================================
@@ -290,10 +309,14 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
         slices.push(n_slice);
     }
 
-    function tr_slice_show(slice) {
+    async function tr_slice_show(slice) {
         if (slice.tr_data) {
-            if (!slice.tree)
-                slice.tree = traceroute_sum(slice.tr_data);
+            if (!slice.tree) {
+                show_awaiting(true);
+                slice.tree = await traceroute_sum(slice.tr_data);
+            }
+            set_progress(90, 'Drawing');
+            await _yield();
 
             let limits = create_limits(slice.tree.nodes, node_colors);
             taint_nodes(slice.tree.nodes, node_colors, limits);
@@ -309,6 +332,8 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
 
             if (slice.range > 1)
                 update_timeline_window(slice);
+            set_progress(null, '');
+            show_awaiting(false);
         } else {
             show_popup("Empty slice for slice " + slice.slice_no + ' starting ' + slice.start);
         }
@@ -373,7 +398,7 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
     //  Traceroute summarisation
     // ====================================================================
 
-    function traceroute_sum(tr_data) {
+    async function traceroute_sum(tr_data) {
         let nodes = [{ label: 'start', id: 'start', hop: 0, color: { background: '#20C020' } }];
         let node_ix = [];
         let edges = [];
@@ -385,7 +410,12 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
         routers['start'] = 1;
         let start, range;
 
+        let _seen = 0;
         for (let tr of tr_data) {
+            if ((++_seen % CHUNK) === 0) {
+                set_progress(40 + Math.round(50 * _seen / tr_data.length), 'Building topology');
+                await _yield();
+            }
             let last_node = 0, all_hops = [];
             if (!start) start = tr.ts;
             range = tr.ts - start;
@@ -516,10 +546,15 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
     //  OpenSearch to esmond conversion
     // ====================================================================
 
-    function os2esmond_traceroute(os_json) {
+    async function os2esmond_traceroute(os_json) {
         let esmond_json = [];
+        const total = os_json.hits.hits.length;
 
-        for (let tr = 0; tr < os_json.hits.hits.length; tr++) {
+        for (let tr = 0; tr < total; tr++) {
+            if (tr && (tr % CHUNK) === 0) {
+                set_progress(Math.round(40 * tr / total), 'Parsing traceroutes');
+                await _yield();
+            }
             if (Number(params['ip-version']) !== os_json.hits.hits[tr]._source.test.spec['ip-version'])
                 continue;
 
@@ -577,12 +612,13 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
 
         console.log('Fetching traceroutes via: ' + url);
 
-        $.getJSON(url, function (tr_json) {
+        $.getJSON(url, async function (tr_json) {
             slice.tr_data = tr_json;
             if (params.api === 'opensearch') {
-                slice.tr_data = os2esmond_traceroute(tr_json);
+                set_progress(0, 'Parsing traceroutes');
+                slice.tr_data = await os2esmond_traceroute(tr_json);
             }
-            tr_slice_show(slice);
+            await tr_slice_show(slice);
             update_timeline_items(slice);
         })
         .fail(function (jqxhr, textStatus, error) {
@@ -1611,7 +1647,7 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
           <button class="knapp topo-btn" id="${id}-start">Start layout</button>
         </div>
         <div id="${id}-legend"></div>
-        <span id="${id}-awaiting" style="display:none"><div class="spinner"></div></span>
+        <span id="${id}-awaiting" style="display:none"><div class="spinner"></div><span id="${id}-progress" class="tracetree-progress"></span></span>
       </div>
     </div>
     <div id="${id}-stats"></div>


### PR DESCRIPTION
Addresses #130 (reported by @ottojwittner) — the progress-indicator half of it.

### Problem
Parsing and laying out a large trace set (>5k traceroutes) keeps the main thread busy for minutes. The page never repaints during that, so the browser looks frozen and there is nothing to tell the user work is still happening.

### Change
The two heavy stages now process **250 traces at a time and yield to the browser between chunks**, updating a percentage next to the spinner:

| stage | range | label |
|---|---|---|
| `os2esmond_traceroute` (OpenSearch → internal form) | 0–40% | "Parsing traceroutes" |
| `traceroute_sum` (topology + statistics build) | 40–90% | "Building topology" |
| rendering | 90% | "Drawing" |

Both are `async` now, as is `tr_slice_show`. Every call site was already fire-and-forget — `zoom_to_slice` calls `show_time_info` right after, which `tr_slice_show` repeats at the end anyway — so no call site needed changing. The awaiting overlay is toggled through a null-guarded helper.

### Scope — what this does not do
It makes the wait **visible** and keeps the UI responsive (the spinner spins, the page can repaint, the tab is not locked). It does **not** make the parsing itself faster. The heavier options you floated — aggregated OpenSearch queries, or moving the work into a Worker — are still open; happy to take one on if you want to pick a direction.

### Testing
JS syntax-checked, deployed to a test host. Our test host's archive is small (a few thousand traces over a day), so the percentage advances quickly here — a real >5k dataset on your side would be the honest check that the readout paces sensibly.