### PR TITLE
Traceroute viewer: do not filter when no IP version is pinned (#127 follow-up)

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
@@ -520,7 +520,12 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
         let esmond_json = [];
 
         for (let tr = 0; tr < os_json.hits.hits.length; tr++) {
-            if (Number(params['ip-version']) !== os_json.hits.hits[tr]._source.test.spec['ip-version'])
+            // Only filter when the network actually pins a version. mapconfig's
+            // ip_version is a string and an empty one means "all versions" -
+            // but Number('') is 0 (and Number(undefined) NaN), so an unguarded
+            // compare dropped every trace and left the viewer empty.
+            if (params['ip-version'] &&
+                Number(params['ip-version']) !== Number(os_json.hits.hits[tr]._source.test.spec['ip-version']))
                 continue;
 
             let esmond_tr = {};


### PR DESCRIPTION
Follow-up to #128 / #129 — thanks for catching the missing `Number()`, @ottojwittner. One case is still wrong.

`mapconfig` uses an **empty `ip_version` to mean "all versions"** (that is the default in `mapconfig.yml`). With the current compare:

```js
if (Number(params['ip-version']) !== os_json.hits.hits[tr]._source.test.spec['ip-version'])
    continue;
```

`Number('')` is **0**, so `0 !== 4` holds for every record and the conversion drops **all** traces — the traceroute viewer comes up empty for any network that does not pin a version. (`Number(undefined)` gives `NaN`, same effect.) Networks that do pin one, like our `dragonlab` with `ip_version: "4"`, are unaffected, which is why it did not show up on our test host.

Fix: only apply the filter when a version is actually set, and coerce both sides.

```js
if (params['ip-version'] &&
    Number(params['ip-version']) !== Number(os_json.hits.hits[tr]._source.test.spec['ip-version']))
    continue;
```

Note the server side already behaves this way: `get-tracetests.pl` only adds the `test.spec.ip-version` filter for a value of 4 or 6, so an unset version returns all versions there too — this brings the client in line.

### Testing
JS syntax-checked. Verified on a test host with `ip_version: "4"` (unchanged, still shows its v4 traces); the empty-version path is the one this restores.