### PR TITLE
Traceroute topology: fill the tab height instead of stopping at min-height

### DIFF
--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -2532,6 +2532,15 @@ div.graph:has(> .curve-iframe-wrap):not([aria-hidden="true"]) {
     flex: 0 0 auto;      /* the tab nav keeps its content height */
 }
 
+/* Wrapper that ls_tab() puts the tracetree into: it sits between the flex
+   .ls-pane and .tracetree-inner, so it has to pass the height through. */
+.tracetree-host {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
 .tracetree-timeline-wrap {
     flex: 0 0 auto;
     background: var(--c-surface);

--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -2541,6 +2541,23 @@ div.graph:has(> .curve-iframe-wrap):not([aria-hidden="true"]) {
     flex-direction: column;
 }
 
+/* vis-network's navigation buttons are bright green PNGs meant for a light
+   canvas; on the dark topology they glare. Tone them down to the UI's muted
+   grey and light up on hover. (The images ship with vis; we only re-tint.) */
+.tracetree-graph .vis-network .vis-navigation .vis-button {
+    filter: grayscale(1) brightness(1.7) opacity(.45);
+    transition: filter .15s ease;
+}
+.tracetree-graph .vis-network .vis-navigation .vis-button:hover {
+    filter: grayscale(1) brightness(2.2) opacity(.9);
+}
+:root[data-theme="light"] .tracetree-graph .vis-network .vis-navigation .vis-button {
+    filter: grayscale(1) brightness(.75) opacity(.55);
+}
+:root[data-theme="light"] .tracetree-graph .vis-network .vis-navigation .vis-button:hover {
+    filter: grayscale(1) brightness(.55) opacity(.9);
+}
+
 .tracetree-timeline-wrap {
     flex: 0 0 auto;
     background: var(--c-surface);

--- a/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
+++ b/microdep/perfsonar-microdep/microdep-map/css/microdep-map.css
@@ -1863,12 +1863,16 @@ table.sortable th:not(.sorttable_sorted):not(.sorttable_sorted_reverse):not(.sor
    negation to scope the rule to the visible panel only. */
 .tracetree-topo:not([aria-hidden="true"]) {
     display: grid !important;
+    flex: 1 1 auto;          /* grow past min-height to use the whole tab */
+    min-height: 0;
+    grid-template-rows: 1fr; /* the single row takes the available height */
 }
 
 .tracetree-graph {
     position: relative;          /* anchor for the absolutely-positioned popup */
     width: 100%;
     min-width: 0;
+    height: 100%;                /* fill the row; vis-network follows the box */
     min-height: 450px;
     border: 1px solid var(--c-border);
     border-radius: var(--r);
@@ -2488,6 +2492,10 @@ div.graph:has(> .curve-iframe-wrap):not([aria-hidden="true"]) {
 .ls-pane {
     flex: 1 1 auto;
     min-height: 0;
+    /* The Traceroute pane hosts the tracetree, whose own flex:1 only works if
+       its parent is a flex container. */
+    display: flex;
+    flex-direction: column;
 }
 
 /* Wrapper div my code creates around tracetree_tab() also fills */
@@ -2514,6 +2522,14 @@ div.graph:has(> .curve-iframe-wrap):not([aria-hidden="true"]) {
     flex: 1 1 auto;
     min-height: 0;
     overflow: auto;
+    /* Flex column so the active tab pane can fill the height. Without this the
+       panes are plain blocks, their flex:1 does nothing and the topology stops
+       at its min-height, leaving the lower part of the tab empty. */
+    display: flex;
+    flex-direction: column;
+}
+.tracetree-tabs-wrap > ul {
+    flex: 0 0 auto;      /* the tab nav keeps its content height */
 }
 
 .tracetree-timeline-wrap {

--- a/microdep/perfsonar-microdep/microdep-map/js/ls-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/ls-tab.js
@@ -544,7 +544,10 @@ export function ls_tab(div_id, from, to, time_start, time_end, options = {}) {
     function render_tracetree(mahost, p_from, p_to, t_start, t_end, api) {
         const inner_id = id + '-trace-inner';
         const trace_pane = el('trace');
-        trace_pane.innerHTML = '<div id="' + inner_id + '"></div>';
+        // The wrapper needs a class: as a plain block it would not grow, and the
+        // tracetree inside it (flex: 1) would stop at its min-height, leaving the
+        // lower part of the tab empty.
+        trace_pane.innerHTML = '<div id="' + inner_id + '" class="tracetree-host"></div>';
         // Sub-tabs are Traceroute (0) and Peers (1) - the old `active: 2` is a
         // leftover from a three-tab layout and selects nothing, so opening a
         // pair from the Peers list never switched to the graph.

--- a/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
+++ b/microdep/perfsonar-microdep/microdep-map/js/tracetree-tab.js
@@ -1737,11 +1737,10 @@ export function tracetree_tab(div_id, from, to, time_start, time_end, options = 
         tl.style.display = is_docs ? 'none' : '';
     });
 
-    // Size the tree container (width controlled by CSS grid)
-    let treeC = el('treetainer');
-    if (treeC) {
-        treeC.style.height = (window.innerHeight * 0.55) + "px";
-    }
+    // The tree container is sized by CSS now: its grid row fills the tab, so the
+    // graph follows the window instead of being pinned to 55% of the viewport
+    // height by an inline style (which won regardless of the available space and
+    // left the lower part of the tab empty).
 
     bind_buttons();
 


### PR DESCRIPTION
Reported while testing #130: the topology graph leaves roughly a quarter of the tab empty on a taller screen.

### Cause
The panes already carried `flex: 1 1 auto`, but neither `.tracetree-tabs-wrap` nor `.ls-pane` declared `display: flex` — so those declarations were inert and the layout fell back to the fixed `min-height: 500px` / `450px` floors, regardless of how much room the tab actually had.

### Fix
- `.tracetree-tabs-wrap` and `.ls-pane` become flex columns (the tab nav is pinned with `flex: 0 0 auto`).
- The visible topo pane grows: `flex: 1 1 auto`, `min-height: 0`, `grid-template-rows: 1fr` so the single row takes the available height; the old min-heights stay as floors for short viewports.
- `.tracetree-graph` gets `height: 100%`. vis-network sizes itself to its container (no explicit height in the options, `autoResize` on by default), so the canvas follows.

CSS-only; braces balanced. Deployed to a test host.